### PR TITLE
add GPU support for JAX in SecretFlow

### DIFF
--- a/docker/sf-gpu.Dockerfile
+++ b/docker/sf-gpu.Dockerfile
@@ -1,3 +1,25 @@
 FROM tensorflow/tensorflow:2.10.1-gpu
-
+#install the dependencies of cuda11
+#you are supposed to  add the mirror source of pypi to accelerate installation of nvidia packages of cuda11, 
+#if not, the building of images are prone to fail very much 
+RUN pip install nvidia-cublas-cu11 \
+    && pip install nvidia-cuda-cupti-cu11 \
+    && pip install nvidia-cuda-nvcc-cu11 \
+    && pip install nvidia-cuda-nvrtc-cu11 \
+    && pip install nvidia-cuda-runtime-cu11 \
+    && pip install nvidia-cudnn-cu11 \
+    && pip install nvidia-cufft-cu11 \
+    && pip install nvidia-curand-cu11 \
+    && pip install nvidia-cusolver-cu11 \
+    && pip install nvidia-cusparse-cu11 \
+    && pip install nvidia-nccl-cu11 \
+    && pip install nvidia-nvtx-cu11 \
+# install the gpu version of jax and jaxlib based cuda11
+# the site of https://storage.googleapis.com/jax-releases/jax_cuda_releases.html is very necessary
+# ref to https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier
+RUN pip install --upgrade "jax[cuda11_pip]"==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
+    && pip install --upgrade "jaxlib[cuda11_pip]"==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+#install secretflow
+#you are supposed to add the mirror source of pypi to accelerate installation of SecretFlow and accelerate the building of images
+#if not, the building of images are prone to fail very much 
 RUN pip install -U secretflow

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -108,9 +108,13 @@ conda activate sf
 pip install -U secretflow
 ```
 
-## GPU support
+## GPUs support
 
-NVIDIA's CUDA and cuDNN are typically used to accelerate the training and testing of Tensoflow and PyTorch deep learning models. Tensoflow and PyTorch are both deep learning backends for SecretFlow, and if you want to use GPU acceleration in SecretFlow, you can follow these steps:
+NVIDIA's CUDA and cuDNN are typically used to accelerate the training and testing of Tensoflow and PyTorch deep learning models. Tensoflow and PyTorch are both deep learning backends for SecretFlow.
+
+[JAX]([google/jax: Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT to GPU/TPU, and more (github.com)](https://github.com/google/jax)) is the frontend highly recommended by the SecretFlow team. JAX can compile and run your NumPy code on accelerators, such as GPUs and TPUs.Now we supply GPUs supports to JAX in SecretFlow.
+
+if you want to use GPU acceleration in SecretFlow, you can follow these steps:
 
 1. Make sure your NVIDIA driver is available
 
@@ -143,7 +147,7 @@ docker container run -it --gpus all secretflow-gpu bash
 
 - `--gpus all`: This parameter is essential.
 
-5. After the container is running, you can use the jupyter notebook [GPU Check](../tutorial/GPU_check.ipynb) to check the callability of Tensorflow and PyTorch for NVIDIA GPUs inside the container.
+5. After the container is running, you can use the jupyter notebook [GPU Check](../tutorial/GPU_check.ipynb) to check the callability of JAX, Tensorflow and PyTorch for NVIDIA GPUs inside the container.
 
 ## A quick try
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -116,7 +116,13 @@ NVIDIA's CUDA and cuDNN are typically used to accelerate the training and testin
 
 if you want to use GPU acceleration in SecretFlow, you can follow these steps:
 
-1. Make sure your NVIDIA driver is available
+1. Make sure your NVIDIA driver is available and meet the version requirements as [JAX recommend]([google/jax: Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT to GPU/TPU, and more (github.com)](https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier)).
+
+- The version requirements:
+
+ the driver must be version >= 525.60.13 for CUDA 12 and >= 450.80.02 for CUDA 11 on Linux.
+
+- Run NVIDIA System Management Interface (nvidia-smi) to make sure your NVIDIA driver is available and meet the version requirements.
 
 ```bash
 nvidia-smi

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -112,7 +112,7 @@ pip install -U secretflow
 
 NVIDIA's CUDA and cuDNN are typically used to accelerate the training and testing of Tensoflow and PyTorch deep learning models. Tensoflow and PyTorch are both deep learning backends for SecretFlow.
 
-[JAX]([google/jax: Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT to GPU/TPU, and more (github.com)](https://github.com/google/jax)) is the frontend highly recommended by the SecretFlow team. JAX can compile and run your NumPy code on accelerators, such as GPUs and TPUs.Now we supply GPUs supports to JAX in SecretFlow.
+[JAX](https://github.com/google/jax) is the frontend highly recommended by the SecretFlow team. JAX can compile and run your NumPy code on accelerators, such as GPUs and TPUs.Now we supply GPUs supports to JAX in SecretFlow.
 
 if you want to use GPU acceleration in SecretFlow, you can follow these steps:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -116,7 +116,7 @@ NVIDIA's CUDA and cuDNN are typically used to accelerate the training and testin
 
 if you want to use GPU acceleration in SecretFlow, you can follow these steps:
 
-1. Make sure your NVIDIA driver is available and meet the version requirements as [JAX recommend]([google/jax: Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT to GPU/TPU, and more (github.com)](https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier)).
+1. Make sure your NVIDIA driver is available and meet the version requirements as [JAX recommend](https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier).
 
 - The version requirements:
 

--- a/docs/tutorial/GPU_check.ipynb
+++ b/docs/tutorial/GPU_check.ipynb
@@ -13,22 +13,27 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "5c993d00",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:49.989079Z",
+     "end_time": "2023-04-13T17:18:50.855038Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wed Feb  8 14:02:39 2023       \r\n",
+      "Thu Apr 13 17:18:51 2023       \r\n",
       "+-----------------------------------------------------------------------------+\r\n",
-      "| NVIDIA-SMI 515.65.01    Driver Version: 516.94       CUDA Version: 11.7     |\r\n",
+      "| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |\r\n",
       "|-------------------------------+----------------------+----------------------+\r\n",
       "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\r\n",
       "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\r\n",
       "|                               |                      |               MIG M. |\r\n",
       "|===============================+======================+======================|\r\n",
-      "|   0  NVIDIA GeForce ...  On   | 00000000:01:00.0 Off |                  N/A |\r\n",
-      "| N/A   46C    P8    N/A /  N/A |      0MiB /  4096MiB |      0%      Default |\r\n",
+      "|   0  NVIDIA A10-4Q       On   | 00000000:00:07.0 Off |                  N/A |\r\n",
+      "| N/A   N/A    P0    N/A /  N/A |    128MiB /  3932MiB |      0%      Default |\r\n",
       "|                               |                      |                  N/A |\r\n",
       "+-------------------------------+----------------------+----------------------+\r\n",
       "                                                                               \r\n",
@@ -47,45 +52,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Import PyTorch to check GPU devices"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7b1f6941",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-02-08 14:02:40.098592: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2023-02-08 14:02:40.247683: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n"
-     ]
+   "id": "7bfa0d38",
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:50.852002Z",
+     "end_time": "2023-04-13T17:18:51.794978Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
-    "import tensorflow as tf"
+    "import torch"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "2194f97b",
-   "metadata": {},
    "source": [
-    "Check TensorFlow version"
-   ]
+    "Check the version of PyTorch"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "dd82d9d3",
-   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "'2.10.0'"
-      ]
+      "text/plain": "'2.0.0+cu117'"
      },
      "execution_count": 3,
      "metadata": {},
@@ -93,224 +98,41 @@
     }
    ],
    "source": [
-    "tf.__version__"
-   ]
+    "torch.__version__"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:51.799271Z",
+     "end_time": "2023-04-13T17:18:51.827270Z"
+    }
+   }
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "ad28a35f",
-   "metadata": {},
    "source": [
-    "Check if TensorFlow can call GPUs"
-   ]
+    "Check if PyTorch can call GPUs"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e2ad0162",
-   "metadata": {},
+   "id": "84e571e1",
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:51.824271Z",
+     "end_time": "2023-04-13T17:18:51.890823Z"
+    }
+   },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /tmp/ipykernel_1496/337460670.py:1: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use `tf.config.list_physical_devices('GPU')` instead.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-02-08 14:02:42.417418: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2023-02-08 14:02:42.437044: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:42.441833: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:42.442153: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.175909: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.176632: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.176662: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1700] Could not identify NUMA node of platform GPU id 0, defaulting to 0.  Your kernel may not have been built with NUMA support.\n",
-      "2023-02-08 14:02:43.177122: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.177196: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /device:GPU:0 with 2742 MB memory:  -> device: 0, name: NVIDIA GeForce GTX 1050, pci bus id: 0000:01:00.0, compute capability: 6.1\n"
-     ]
-    },
-    {
      "data": {
-      "text/plain": [
-       "True"
-      ]
+      "text/plain": "True"
      },
      "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tf.test.is_gpu_available()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "1db906bf",
-   "metadata": {},
-   "source": [
-    "Check physical GPUs in TensorFlow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "0afd81b2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-02-08 14:02:43.192442: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.193021: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.193388: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tf.config.list_physical_devices('GPU')"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "f568704a",
-   "metadata": {},
-   "source": [
-    "Check the GPU type of the computer in TensorFlow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "68dbd9ec",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "device: 0, name: NVIDIA GeForce GTX 1050, pci bus id: 0000:01:00.0, compute capability: 6.1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-02-08 14:02:43.212331: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.213369: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.213868: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.214563: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.214581: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1700] Could not identify NUMA node of platform GPU id 0, defaulting to 0.  Your kernel may not have been built with NUMA support.\n",
-      "2023-02-08 14:02:43.214991: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:966] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2023-02-08 14:02:43.215067: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /device:GPU:0 with 2742 MB memory:  -> device: 0, name: NVIDIA GeForce GTX 1050, pci bus id: 0000:01:00.0, compute capability: 6.1\n"
-     ]
-    }
-   ],
-   "source": [
-    "from tensorflow.python.client import device_lib\n",
-    "\n",
-    "local_device_protos = device_lib.list_local_devices()\n",
-    "for x in local_device_protos:\n",
-    "    if x.device_type == 'GPU':\n",
-    "        print(x.physical_device_desc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "7bfa0d38",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "9e2a465c",
-   "metadata": {},
-   "source": [
-    "Check PyTorch version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "b02e4d33",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'1.10.1+cu102'"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "torch.__version__"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "b095b63e",
-   "metadata": {},
-   "source": [
-    "Check if PyTorch can call GPUs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "84e571e1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,9 +152,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "b37ff8de",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:51.854727Z",
+     "end_time": "2023-04-13T17:18:51.897822Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -358,15 +185,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "b8b9a570",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:51.882725Z",
+     "end_time": "2023-04-13T17:18:51.897822Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GPU 0.: NVIDIA GeForce GTX 1050\n"
+      "GPU 0.: NVIDIA A10-4Q\n"
      ]
     }
    ],
@@ -374,6 +206,439 @@
     "for i in range(gpu_num):\n",
     "    print('GPU {}.: {}'.format(i,torch.cuda.get_device_name(i)))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Import TensorFlow to check GPU devices"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-04-13 17:18:52.308723: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2023-04-13 17:18:52.422989: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2023-04-13 17:18:52.453216: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2023-04-13 17:18:52.918465: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvrtc.so.11.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda-11.2/lib64:/home/limingbo/anaconda3/envs/tensorflow/lib:/home/limingbo/TensorRT-7.2.3.4/lib\n",
+      "2023-04-13 17:18:52.918653: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvrtc.so.11.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda-11.2/lib64:/home/limingbo/anaconda3/envs/tensorflow/lib:/home/limingbo/TensorRT-7.2.3.4/lib\n",
+      "2023-04-13 17:18:52.918661: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:51.882725Z",
+     "end_time": "2023-04-13T17:18:53.523525Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the version of TensorFlow"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'2.10.1'"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.__version__"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:53.526524Z",
+     "end_time": "2023-04-13T17:18:53.579778Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check if TensorFlow can call GPUs"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /tmp/ipykernel_345917/2294581100.py:1: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use `tf.config.list_physical_devices('GPU')` instead.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-04-13 17:18:54.000431: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2023-04-13 17:18:54.001471: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:54.012039: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:54.012246: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.755971: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.756159: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.756317: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.756460: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /device:GPU:0 with 1415 MB memory:  -> device: 0, name: NVIDIA A10-4Q, pci bus id: 0000:00:07.0, compute capability: 8.6\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.test.is_gpu_available()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:53.578771Z",
+     "end_time": "2023-04-13T17:18:56.347645Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check physical GPUs in TensorFlow"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-04-13 17:18:56.761259: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.761449: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.761587: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.config.list_physical_devices('GPU')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.363645Z",
+     "end_time": "2023-04-13T17:18:56.401645Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the GPU type of the computer in TensorFlow"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "device: 0, name: NVIDIA A10-4Q, pci bus id: 0000:00:07.0, compute capability: 8.6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-04-13 17:18:56.765979: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.766168: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.766340: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.766507: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.766647: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:980] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-04-13 17:18:56.766791: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /device:GPU:0 with 1415 MB memory:  -> device: 0, name: NVIDIA A10-4Q, pci bus id: 0000:00:07.0, compute capability: 8.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tensorflow.python.client import device_lib\n",
+    "\n",
+    "local_device_protos = device_lib.list_local_devices()\n",
+    "for x in local_device_protos:\n",
+    "    if x.device_type == 'GPU':\n",
+    "        print(x.physical_device_desc)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.389649Z",
+     "end_time": "2023-04-13T17:18:56.457653Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Import Jax and jaxlib to check GPU devices"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jaxlib"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.419645Z",
+     "end_time": "2023-04-13T17:18:56.505645Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the version of jax and jaxlib"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'0.4.8'"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.__version__"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.505645Z",
+     "end_time": "2023-04-13T17:18:56.505645Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'0.4.7'"
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jaxlib.__version__"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.505645Z",
+     "end_time": "2023-04-13T17:18:56.506646Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check all the devices from the default backend of jax"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[StreamExecutorGpuDevice(id=0, process_index=0, slice_index=0)]"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.devices()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.505645Z",
+     "end_time": "2023-04-13T17:18:56.506646Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the total number of devices of jax"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "1"
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.device_count()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.505645Z",
+     "end_time": "2023-04-13T17:18:56.506646Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the number of JAX processes associated with the backend of jax"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "1"
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.process_count()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.505645Z",
+     "end_time": "2023-04-13T17:18:56.523880Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Check the backend of jaxlib"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gpu\n"
+     ]
+    }
+   ],
+   "source": [
+    "from jax.lib import xla_bridge\n",
+    "print(xla_bridge.get_backend().platform)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.523880Z",
+     "end_time": "2023-04-13T17:18:56.524833Z"
+    }
+   }
   },
   {
    "attachments": {},
@@ -386,9 +651,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 19,
    "id": "c8a443d6",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-13T17:18:56.523880Z",
+     "end_time": "2023-04-13T17:18:56.927007Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import secretflow"


### PR DESCRIPTION
I found the JAX in SecretFlow only support CPU as its backend. when the code is run,  the message appears:
```
No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
```
I  implemented GPU support for JAX in SecretFlow by docker and I run the GPU_check.ipynb to verify that the GPU can be the backend of JAX.
What's more, I finished the the corresponding document.
Please review.