### PR TITLE
Add guide to instruct the update of document and update sh file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ We stick to [Angular Style](https://github.com/angular/angular.js/blob/master/DE
 
 
 ## Documentation update and its multilingual version
-if you upudate the documentation files in `docs/`, you are supposed to update its multilingual version in `docs/locales/zh_CN/LC_MESSAGES`.
+if you update the documentation files in `docs/`, you are supposed to update its multilingual version in `docs/locales/zh_CN/LC_MESSAGES`.
 
 For example, if you update `docs/getting_started/installation.md`, you also need to update the corresponding `*.po` file in `docs/locales/zh_CN/LC_MESSAGES/getting_started/installation.po`.
 
@@ -63,4 +63,5 @@ Follow follwing steps to update documentation:
    sh update_po.sh
    ```
 3. Update the corresponding `*.po` file
-4. only commit the files which you update and pull request
+4. All `fuzzy` should be removed in `*.po` file, because it won't take effect in the Chinese version of the documentation.
+5. only commit the files which you update and pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,21 @@ Pass `-S, --skip-string-normalization` to [black](https://github.com/psf/black) 
 
 ## Git commit message style
 We stick to [Angular Style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
+
+
+## Documentation update and its multilingual version
+if you upudate the documentation files in `docs/`, you are supposed to update its multilingual version in `docs/locales/zh_CN/LC_MESSAGES`.
+
+For example, if you update `docs/getting_started/installation.md`, you also need to update the corresponding `*.po` file in `docs/locales/zh_CN/LC_MESSAGES/getting_started/installation.po`.
+
+Follow follwing steps to update documentation:
+1. Update documentation in `docs`
+2. Run the following command to update `*.po` file
+
+   ```bash
+   cd docs
+   pip install -r requirements.txt
+   sh update_po.sh
+   ```
+3. Update the corresponding `*.po` file
+4. only commit the files which you update and pull request

--- a/docs/update_po.sh
+++ b/docs/update_po.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-make gettext
-sphinx-intl update -p _build/gettext -l zh_CN
-
+mkdir -p _build/gettext &&
+make gettext &&
+sphinx-intl update -p _build/gettext -l zh_CN &&
 echo "po files has been updated. Please update po files in locales folder."


### PR DESCRIPTION
I found if run the `update_po.sh`, it got error;
```
(sf) limingbo@DESKTOP-mingbo:/mnt/d/WorkShop/secretflow/whitelist/secretflow/docs$ sh update_po.sh
: not foundh: 2:
Running Sphinx v5.3.0

Sphinx error:
not registered or available through entry point
] Error 2 [Makefile:20: gettext
: not foundh: 5:
po files has been updated. Please update po files in locales folder.
```
then, I think the sh file need updating to run well.

What's more, Inspired by https://github.com/secretflow/secretflow/pull/305, https://github.com/secretflow/secretflow/pull/556, https://github.com/secretflow/secretflow/pull/550, https://github.com/secretflow/secretflow/pull/551, I think there is a need to add guide document in CONTRIBUTING.md.
please TBR.
