### PR TITLE
Remove cache and tmp in GPU images

### DIFF
--- a/docker/secretflow-gpu.Dockerfile
+++ b/docker/secretflow-gpu.Dockerfile
@@ -15,13 +15,17 @@ RUN if [ ! -e /usr/bin/python3 ]; then ln -sf /usr/bin/python3.8 /usr/bin/python
 RUN pip install nvidia-cublas-cu11 nvidia-cuda-cupti-cu11 nvidia-cuda-nvcc-cu11 \
     nvidia-cuda-nvrtc-cu11 nvidia-cuda-runtime-cu11 install nvidia-cudnn-cu11 \
     nvidia-cufft-cu11  nvidia-curand-cu11  nvidia-cusolver-cu11 \
-    nvidia-cusparse-cu11 nvidia-nccl-cu11  nvidia-nvtx-cu11 
+    nvidia-cusparse-cu11 nvidia-nccl-cu11  nvidia-nvtx-cu11 \
+    && rm -rf  ~/.cache/pip \
+    && rm -rf /tmp/*
 
 # install the gpu version of jax and jaxlib based cuda11
 # the site of https://storage.googleapis.com/jax-releases/jax_cuda_releases.html is very necessary
 # ref to https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier
 RUN pip install --upgrade "jax[cuda11_pip]"==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
-    && pip install --upgrade "jaxlib[cuda11_pip]"==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html 
+    && pip install --upgrade "jaxlib[cuda11_pip]"==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
+    && rm -rf  ~/.cache/pip \
+    && rm -rf /tmp/*
 
 #install secretflows and its dependencies.
 #you are supposed to add the mirror source of pypi to accelerate installation of SecretFlow and accelerate the building of images
@@ -34,7 +38,7 @@ RUN pip install -U secretflow \
     && pip install tensorflow==2.12.0 \
     && pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 \
     && pip install protobuf==3.20.3 \
-    && rm -rf  ~/.cache/pip\
+    && rm -rf  ~/.cache/pip \
     && rm -rf /tmp/*
     
 COPY secretflow_entrypoint.sh /opt/secretflow/

--- a/docker/secretflow-gpu.Dockerfile
+++ b/docker/secretflow-gpu.Dockerfile
@@ -33,10 +33,14 @@ RUN pip install --upgrade "jax[cuda11_pip]"==0.4.1 -f https://storage.googleapis
 RUN pip install -U secretflow \
     && pip install tensorflow==2.12.0 \
     && pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 \
-    && pip install protobuf==3.20.3  
-
+    && pip install protobuf==3.20.3 \
+    && rm -rf  ~/.cache/pip\
+    && rm -rf /tmp/*
+    
 COPY secretflow_entrypoint.sh /opt/secretflow/
 
 COPY secretflow_entrypoint.py /opt/secretflow/
+
+
 
 ENTRYPOINT ["sh","/opt/secretflow/secretflow_entrypoint.sh"]


### PR DESCRIPTION
Remove /root/.cache and /tmp/*  to light the docker image of GPU of SecretFlow.
This operation can reduce disk space usage by 0.1GB.