### PR TITLE
Add papers about Split Learning

### DIFF
--- a/docs/awesome-pets/papers/applications/ppml/sl/attack.md
+++ b/docs/awesome-pets/papers/applications/ppml/sl/attack.md
@@ -1,0 +1,35 @@
+## Attacks Launched by the Client
+
+- [ExPLoit: Extracting Private Labels in Split Learning](https://arxiv.org/pdf/2112.01299.pdf)
+
+- [Label Leakage and Protection in Two-party Split Learning](https://arxiv.org/pdf/2102.08504.pdf)
+
+- [Deep Models Under the GAN: Information Leakage from Collaborative Deep Learning](https://arxiv.org/pdf/1702.07464.pdf)
+
+- [Label Inference Attacks Against Vertical Federated Learning](https://www.usenix.org/conference/usenixsecurity22/presentation/fu-chong)
+
+- [Batch Label Inference and Replacement Attacks in Black-Boxed Vertical Federated Learning](https://arxiv.org/pdf/2112.05409.pdf)
+
+- [Backdoor attacks and defenses in feature-partitioned collaborative learning](https://arxiv.org/pdf/2007.03608.pdf)
+
+- [Defending Batch-Level Label Inference and Replacement Attacks in Vertical Federated Learning](https://ieeexplore.ieee.org/document/9833321)
+
+## Attacks Launched by the Server
+
+- [Can We Use Split Learning on 1D CNN Models for Privacy Preserving Training?](https://arxiv.org/pdf/2003.12365.pdf)
+
+- [UnSplit: Data-Oblivious Model Inversion, Model Stealing, and Label Inference Attacks Against Split Learning](https://arxiv.org/pdf/2108.09033.pdf)
+
+- [PCAT: Functionality and Data Stealing from Split Learning by Pseudo-Client Attack](https://www.usenix.org/conference/usenixsecurity23/presentation/gao)
+
+- [Model Inversion Attacks Against Collaborative Inference](https://dl.acm.org/doi/10.1145/3359789.3359824)
+
+- [Attacking and Protecting Data Privacy in Edge-Cloud Collaborative Inference Systems](https://ieeexplore.ieee.org/document/9187880)
+
+- [Overlearning Reveals Sensitive Attributes](https://arxiv.org/pdf/1905.11742.pdf)
+
+- [Practical Membership Inference Attack Against Collaborative Inference in Industrial IoT](https://ieeexplore.ieee.org/document/9302683)
+
+- [Unleashing the Tiger: Inference Attacks on Split Learning](https://arxiv.org/pdf/2012.02670.pdf)
+
+- [Feature Space Hijacking Attacks against Differentially Private Split Learning](https://arxiv.org/pdf/2201.04018.pdf)

--- a/docs/awesome-pets/papers/applications/ppml/sl/defense.md
+++ b/docs/awesome-pets/papers/applications/ppml/sl/defense.md
@@ -1,0 +1,47 @@
+## Detection and Defenses against Attacks on Split Learning
+
+- [ExPLoit: Extracting Private Labels in Split Learning](https://arxiv.org/pdf/2112.01299.pdf)
+
+- [Shredder: Learning Noise Distributions to Protect Inference Privacy](https://dl.acm.org/doi/10.1145/3373376.3378522)
+
+- [Not Just Privacy: Improving Performance of Private Deep Learning in Mobile Cloud](https://dl.acm.org/doi/10.1145/3219819.3220106)
+
+- [Certified Robustness to Adversarial Examples with Differential Privacy](https://arxiv.org/pdf/1802.03471.pdf)
+
+- [NoPeek: Information leakage reduction to share activations in distributed deep learning](https://arxiv.org/pdf/2008.09161.pdf)
+
+- [NoPeek-Infer: Preventing face reconstruction attacks in distributed inference after on-premise training](https://ieeexplore.ieee.org/document/9667085)
+
+- [Reducing leakage in distributed deep learning for sensitive health data](https://www.media.mit.edu/publications/reducing-leakage-in-distributed-deep-learning-for-sensitive-health-data-accepted-to-iclr-2019-workshop-on-ai-for-social-good-2019/)
+
+- [Label Inference Attacks Against Vertical Federated Learning](https://www.usenix.org/conference/usenixsecurity22/presentation/fu-chong)
+
+- [Batch Label Inference and Replacement Attacks in Black-Boxed Vertical Federated Learning](https://arxiv.org/pdf/2112.05409.pdf)
+
+- [Can We Use Split Learning on 1D CNN Models for Privacy Preserving Training?](https://arxiv.org/pdf/2003.12365.pdf)
+
+- [Practical defences against model inversion attacks for split neural networks](https://arxiv.org/pdf/2104.05743.pdf)
+
+- [Privacy Adversarial Network: Representation Learning for Mobile Data Privacy](https://arxiv.org/pdf/2006.06535.pdf)
+
+- [Adversarial Learning of Privacy-Preserving and Task-Oriented Representations](https://arxiv.org/pdf/1911.10143.pdf)
+
+- [DeepObfuscator: Obfuscating Intermediate Representations with Privacy-Preserving Adversarial Learning on Smartphones](https://arxiv.org/pdf/1909.04126.pdf)
+
+- [Privacy-Preserving Image Template Sharing Using Contrastive Learning](https://www.mdpi.com/1099-4300/24/5/643)
+
+- [ResSFL: A Resistance Transfer Framework for Defending Model Inversion Attack in Split Federated Learning](https://arxiv.org/pdf/2205.04007.pdf)
+
+- [Attacking and Protecting Data Privacy in Edge-Cloud Collaborative Inference Systems](https://ieeexplore.ieee.org/document/9187880)
+
+- [Improving Robustness to Model Inversion Attacks via Mutual Information Regularization](https://arxiv.org/pdf/2009.05241.pdf)
+
+- [MixCon: Adjusting the Separability of Data Representations for Harder Data Recovery](https://arxiv.org/pdf/2010.11463.pdf)
+
+- [SplitGuard: Detecting and Mitigating Training-Hijacking Attacks in Split Learning](https://arxiv.org/pdf/2108.09052.pdf)
+
+- [Differentially Private CutMix for Split Learning with Vision Transformer](https://arxiv.org/pdf/2210.15986.pdf)
+
+- [DISCO: Dynamic and Invariant Sensitive Channel Obfuscation for deep neural networks](https://arxiv.org/pdf/2012.11025.pdf)
+
+- [Unsupervised Information Obfuscation for Split Inference of Neural Networks](https://arxiv.org/pdf/2104.11413.pdf)

--- a/docs/awesome-pets/papers/applications/ppml/sl/introduction_and_application.md
+++ b/docs/awesome-pets/papers/applications/ppml/sl/introduction_and_application.md
@@ -1,0 +1,46 @@
+## Introdiction and Application about Split Learning
+- [A Study of Split Learning Model](https://ieeexplore.ieee.org/document/9721798)
+
+- [Distributed learning of deep neural network over multiple agents](https://arxiv.org/pdf/1810.06060.pdf)
+
+- [Split Learning for collaborative deep learning in healthcare](https://arxiv.org/pdf/1912.12115.pdf)
+
+- [Split learning for health: Distributed deep learning without sharing raw patient data](https://arxiv.org/pdf/1812.00564.pdf)
+
+- [Detailed comparison of communication efficiency of split learning and federated learning](https://arxiv.org/pdf/1909.09145.pdf)
+
+- [Advancements of federated learning towards privacy preservation: from federated learning to split learning](https://arxiv.org/pdf/2011.14818.pdf)
+
+- [End-to-End Evaluation of Federated Learning and Split Learning for Internet of Things](https://arxiv.org/pdf/2003.13376.pdf)
+
+- [Multiple Classification with Split Learning](https://arxiv.org/pdf/2008.09874.pdf)
+
+- [One Pixel Image and RF Signal Based Split Learning for mmWave Received Power Prediction](https://arxiv.org/pdf/1911.01682.pdf)
+
+- [FedSL: Federated Split Learning on Distributed Sequential Data in Recurrent Neural Networks](https://arxiv.org/pdf/2011.03180.pdf)
+
+- [SplitNN-driven Vertical Partitioning](https://arxiv.org/pdf/2008.04137.pdf)
+
+- [Privacy-Sensitive Parallel Split Learning](https://ieeexplore.ieee.org/document/9016486)
+
+- [SplitEasy: A Practical Approach for Training ML models on Mobile Devices](https://arxiv.org/pdf/2011.04232.pdf)
+
+- [PyVertical: A Vertical Federated Learning Framework for Multi-headed SplitNN](https://arxiv.org/pdf/2104.00489.pdf)
+
+- [ExpertMatcher: Automating ML Model Selection for Clients using Hidden Representations](https://arxiv.org/pdf/1910.03731.pdf)
+
+- [SplitFed: When Federated Learning Meets Split Learning](https://arxiv.org/pdf/2004.12088.pdf)
+
+- [AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed Deep Learning](https://arxiv.org/pdf/2112.01637.pdf)
+
+- [Neurosurgeon: Collaborative Intelligence Between the Cloud and Mobile Edge](https://dl.acm.org/doi/10.1145/3037697.3037698)
+
+- [Auto-Split: A General Framework of Collaborative Edge-Cloud AI](https://dl.acm.org/doi/abs/10.1145/3447548.3467078)
+
+- [A Hybrid Deep Learning Architecture for Privacy-Preserving Mobile Analytics](https://arxiv.org/pdf/1703.02952.pdf)
+
+- [Federated Split Vision Transformer for COVID-19 CXR Diagnosis using Task-Agnostic Training](https://arxiv.org/pdf/2111.01338.pdf)
+
+- [Improving the Communication and Computation Efficiency of Split Learning for IoT Applications](https://ieeexplore.ieee.org/document/9685493)
+
+- [On the Feasibility of Split Learning, Transfer Learning and Federated Learning for Preserving Security in ITS Systems](https://ieeexplore.ieee.org/document/9756883)

--- a/docs/awesome-pets/papers/applications/ppml/sl/sl.md
+++ b/docs/awesome-pets/papers/applications/ppml/sl/sl.md
@@ -1,14 +1,8 @@
 # Split Learning
-Federated learning is a popular distributed machine learning framework in which clients aggregate their learned models without sharing their individual data under privacy-preserving consideration. However, FL is still facing many challenges, among which efficiency, accuracy, security and fairness challenges are the main problems that hinder the development of FL.
+Split Learning is considerd a solution for machine learning privacy that takes place between clients and servers. In this way, the model is split and trained, so that the original data does not move to the client and the server, reducing the burden of training.
 
-1. [Survey](survey.md)
-2. [Datasets](datasets.md)
-3. [Efficiency](Efficiency.md)  
-Computation,Communication,Quantization
-4. [Effectiveness](Effectiveness.md)  
-Non_IID, Accuracy challenge, Convergence, Robustness
-5. [Incentive](incentive.md)
-6. [Vertical FL](vertical.md)
-7. [Boosting](boosting.md)
-8. [Application](application.md)
+1. [Introduction and Application](introduction_and_application.md)
+2. [Attack](attack.md)
+3. [Defense](defense.md)  
+
 

--- a/docs/awesome-pets/papers/applications/ppml/sl/sl.md
+++ b/docs/awesome-pets/papers/applications/ppml/sl/sl.md
@@ -1,0 +1,14 @@
+# Split Learning
+Federated learning is a popular distributed machine learning framework in which clients aggregate their learned models without sharing their individual data under privacy-preserving consideration. However, FL is still facing many challenges, among which efficiency, accuracy, security and fairness challenges are the main problems that hinder the development of FL.
+
+1. [Survey](survey.md)
+2. [Datasets](datasets.md)
+3. [Efficiency](Efficiency.md)  
+Computation,Communication,Quantization
+4. [Effectiveness](Effectiveness.md)  
+Non_IID, Accuracy challenge, Convergence, Robustness
+5. [Incentive](incentive.md)
+6. [Vertical FL](vertical.md)
+7. [Boosting](boosting.md)
+8. [Application](application.md)
+


### PR DESCRIPTION
**Type of change**

- [ ] Add new category and papers 


**Description**

> Split Learning, which is also an improtant aspect, is considerd a solution for machine learning privacy that takes place between clients and servers. So I add some papers about the introduction and applications of Split Learning. Meanwhile, there are some works about the security of Split Learning, so I add these works categorized by Attacks and Defenses. Also I make new directory according to the category.

