### PR TITLE
Update psi.md

### DIFF
--- a/docs/awesome-pets/papers/applications/set/psi.md
+++ b/docs/awesome-pets/papers/applications/set/psi.md
@@ -57,6 +57,10 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
   *Gayathri Garimella, Payman Mohassel, Mike Rosulek, Saeed Sadeghian, Jaspal Singh*
   PKC 2021, [eprint](https://eprint.iacr.org/2021/243), GMRS21
 
+- Oblivious Key-Value Stores and Amplification for Private Set Intersection
+  *Gayathri Garimella, Benny Pinkas, Mike Rosulek, Ni Trieu, and Avishay Yanai*
+  Crypto 2021, [eprint](https://eprint.iacr.org/2021/883), GPR+21
+
 - PSI from PaXoS: Fast, Malicious Private Set Intersection
   *Benny Pinkas, Mike Rosulek, Ni Trieu, Avishay Yanai*
   EuroCrypt 2020, [eprint](https://eprint.iacr.org/2020/193), PaXoS


### PR DESCRIPTION
**Type of change**

- [x] Add new papers (Please tell us why you think this paper is awesome!)
- [ ] Fix the category of an existing paper/papers (Please tell us the reasons)
- [ ] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**

> Please include a summary of the change and the relevant motivation. 

Add a new **Crypto21** paper:  Oblivious Key-Value Stores and Amplification for Private Set Intersection
. This paper consider a more general notion of an oblivious key-value store (OKVS), and show new constructions resulting in the fastest OKVS to date.