### PR TITLE
refactor:add a simpler implement of step of each epoch

### DIFF
--- a/docs/tutorial/CustomDataLoaderTorch.ipynb
+++ b/docs/tutorial/CustomDataLoaderTorch.ipynb
@@ -364,7 +364,7 @@
     "):\n",
     "    def dataset_builder(x, stage=\"train\"):\n",
     "        \"\"\" \"\"\"\n",
-    "        \n",
+    "\n",
     "        import numpy as np\n",
     "        from torch.utils.data import DataLoader\n",
     "        from torch.utils.data.sampler import SubsetRandomSampler\n",

--- a/docs/tutorial/CustomDataLoaderTorch.ipynb
+++ b/docs/tutorial/CustomDataLoaderTorch.ipynb
@@ -52,10 +52,17 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The version of SecretFlow: 1.2.0.dev20230918\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-04-17 15:14:51,955\tINFO worker.py:1538 -- Started a local Ray instance.\n"
+      "2023-10-02 04:16:06,736\tINFO worker.py:1538 -- Started a local Ray instance.\n"
      ]
     }
    ],
@@ -163,11 +170,21 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-10-02 04:16:08.615009: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory\n",
+      "2023-10-02 04:16:09.386429: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory\n",
+      "2023-10-02 04:16:09.386495: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory\n",
+      "2023-10-02 04:16:09.386502: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Downloading data from https://secretflow-data.oss-accelerate.aliyuncs.com/datasets/tf_flowers/flower_photos.tgz\n",
-      "67588319/67588319 [==============================] - 1s 0us/step\n"
+      "67588319/67588319 [==============================] - 3s 0us/step\n"
      ]
     }
    ],
@@ -278,6 +295,40 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "01edf311",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset size: 1201\n",
+      "train dataset size: 960\n",
+      "way1: train_step_per_epoch: 30\n",
+      "way2: train_step_per_epoch: 30\n",
+      "test dataset size: 241\n",
+      "way1: test_step_per_epoch: 8\n",
+      "way2: test_step_per_epoch: 8\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "print(\"dataset size:\", dataset_size)\n",
+    "\n",
+    "print(\"train dataset size:\", split)\n",
+    "print(\"way1: train_step_per_epoch:\", math.ceil(split / batch_size))\n",
+    "print(\"way2: train_step_per_epoch:\", len(train_loader))\n",
+    "\n",
+    "print(\"test dataset size:\", dataset_size - split)\n",
+    "print(\"way1: test_step_per_epoch:\", math.ceil((dataset_size - split) / batch_size))\n",
+    "print(\"way2: test_step_per_epoch:\", len(valid_loader))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "85d6833a",
    "metadata": {},
@@ -300,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "9a502be1",
    "metadata": {},
    "outputs": [],
@@ -313,8 +364,7 @@
     "):\n",
     "    def dataset_builder(x, stage=\"train\"):\n",
     "        \"\"\" \"\"\"\n",
-    "        import math\n",
-    "\n",
+    "        \n",
     "        import numpy as np\n",
     "        from torch.utils.data import DataLoader\n",
     "        from torch.utils.data.sampler import SubsetRandomSampler\n",
@@ -328,7 +378,6 @@
     "            ]\n",
     "        )\n",
     "        flower_dataset = datasets.ImageFolder(x, transform=flower_transform)\n",
-    "        dataset_size = len(flower_dataset)\n",
     "        # Define sampler\n",
     "\n",
     "        indices = list(range(dataset_size))\n",
@@ -350,11 +399,10 @@
     "\n",
     "        # Return\n",
     "        if stage == \"train\":\n",
-    "            train_step_per_epoch = math.ceil(split / batch_size)\n",
-    "\n",
+    "            train_step_per_epoch = len(train_loader)\n",
     "            return train_loader, train_step_per_epoch\n",
     "        elif stage == \"eval\":\n",
-    "            eval_step_per_epoch = math.ceil((dataset_size - split) / batch_size)\n",
+    "            eval_step_per_epoch = len(valid_loader)\n",
     "            return valid_loader, eval_step_per_epoch\n",
     "\n",
     "    return dataset_builder"
@@ -370,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1b45c27b",
    "metadata": {},
    "outputs": [],
@@ -418,10 +466,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "bdeb305f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/envs/limingbo_oscp/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from secretflow.ml.nn.utils import BaseModule\n",
     "\n",
@@ -450,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c1801328",
    "metadata": {},
    "outputs": [],
@@ -465,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c1939910",
    "metadata": {},
    "outputs": [
@@ -530,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5f2cfe44",
    "metadata": {},
    "outputs": [
@@ -538,12 +595,72 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:FL Train Params: {'self': <secretflow.ml.nn.fl.fl_model.FLModel object at 0x7ff4efc87af0>, 'x': {alice: '/tmp/tmp59nrtvl5/datasets/flower_photos', bob: '/tmp/tmp59nrtvl5/datasets/flower_photos'}, 'y': None, 'batch_size': 32, 'batch_sampling_rate': None, 'epochs': 5, 'verbose': 1, 'callbacks': None, 'validation_data': {alice: '/tmp/tmp59nrtvl5/datasets/flower_photos', bob: '/tmp/tmp59nrtvl5/datasets/flower_photos'}, 'shuffle': False, 'class_weight': None, 'sample_weight': None, 'validation_freq': 1, 'aggregate_freq': 2, 'label_decoder': None, 'max_batch_size': 20000, 'prefetch_buffer_size': None, 'sampler_method': 'batch', 'random_seed': 1234, 'dp_spent_step_freq': 1, 'audit_log_dir': None, 'dataset_builder': {alice: <function create_dataset_builder.<locals>.dataset_builder at 0x7ff600fb7ee0>, bob: <function create_dataset_builder.<locals>.dataset_builder at 0x7ff6007148b0>}}\n",
-      "100%|██████████| 30/30 [00:32<00:00,  1.08s/it, epoch: 1/5 -  multiclassaccuracy:0.3760416805744171  multiclassprecision:0.3760416805744171  val_multiclassaccuracy:0.0  val_multiclassprecision:0.0 ]\n",
-      "100%|██████████| 8/8 [00:10<00:00,  1.27s/it, epoch: 2/5 -  multiclassaccuracy:0.5078125  multiclassprecision:0.5078125  val_multiclassaccuracy:0.1618257313966751  val_multiclassprecision:0.1618257313966751 ]\n",
-      "100%|██████████| 8/8 [00:10<00:00,  1.28s/it, epoch: 3/5 -  multiclassaccuracy:0.51171875  multiclassprecision:0.51171875  val_multiclassaccuracy:0.004149377811700106  val_multiclassprecision:0.004149377811700106 ]\n",
-      "100%|██████████| 8/8 [00:10<00:00,  1.27s/it, epoch: 4/5 -  multiclassaccuracy:0.5390625  multiclassprecision:0.5390625  val_multiclassaccuracy:0.02074688859283924  val_multiclassprecision:0.02074688859283924 ]\n",
-      "100%|██████████| 8/8 [00:10<00:00,  1.28s/it, epoch: 5/5 -  multiclassaccuracy:0.5703125  multiclassprecision:0.5703125  val_multiclassaccuracy:0.016597511246800423  val_multiclassprecision:0.016597511246800423 ]\n"
+      "INFO:root:FL Train Params: {'self': <secretflow.ml.nn.fl.fl_model.FLModel object at 0x7f7b1f76ce20>, 'x': {PYURuntime(alice): '/tmp/tmpetkohus6/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpetkohus6/datasets/flower_photos'}, 'y': None, 'batch_size': 32, 'batch_sampling_rate': None, 'epochs': 5, 'verbose': 1, 'callbacks': None, 'validation_data': {PYURuntime(alice): '/tmp/tmpetkohus6/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpetkohus6/datasets/flower_photos'}, 'shuffle': False, 'class_weight': None, 'sample_weight': None, 'validation_freq': 1, 'aggregate_freq': 2, 'label_decoder': None, 'max_batch_size': 20000, 'prefetch_buffer_size': None, 'sampler_method': 'batch', 'random_seed': 1234, 'dp_spent_step_freq': 1, 'audit_log_dir': None, 'dataset_builder': {PYURuntime(alice): <function create_dataset_builder.<locals>.dataset_builder at 0x7f7b3096f9d0>, PYURuntime(bob): <function create_dataset_builder.<locals>.dataset_builder at 0x7f7b3096f940>}, 'wait_steps': 100}\n",
+      "100%|██████████| 30/30 [00:24<00:00,  1.16it/s]WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "100%|██████████| 30/30 [00:31<00:00,  1.05s/it, epoch: 1/5 -  multiclassaccuracy:0.3760416805744171  multiclassprecision:0.3760416805744171  val_multiclassaccuracy:0.0  val_multiclassprecision:0.0 ]\n",
+      "100%|██████████| 30/30 [00:22<00:00,  1.25it/s]WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "100%|██████████| 30/30 [00:27<00:00,  1.10it/s, epoch: 2/5 -  multiclassaccuracy:0.5249999761581421  multiclassprecision:0.5249999761581421  val_multiclassaccuracy:0.008298755623400211  val_multiclassprecision:0.008298755623400211 ]\n",
+      "100%|██████████| 30/30 [00:21<00:00,  1.27it/s]WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "100%|██████████| 30/30 [00:26<00:00,  1.14it/s, epoch: 3/5 -  multiclassaccuracy:0.6333333253860474  multiclassprecision:0.6333333253860474  val_multiclassaccuracy:0.0  val_multiclassprecision:0.0 ]\n",
+      "100%|██████████| 30/30 [00:22<00:00,  1.25it/s]WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "100%|██████████| 30/30 [00:26<00:00,  1.13it/s, epoch: 4/5 -  multiclassaccuracy:0.703125  multiclassprecision:0.703125  val_multiclassaccuracy:0.2282157689332962  val_multiclassprecision:0.2282157689332962 ]\n",
+      "100%|██████████| 30/30 [00:22<00:00,  1.25it/s]WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "WARNING:root:Please pay attention to local metrics, global only do naive aggregation \n",
+      "100%|██████████| 30/30 [00:26<00:00,  1.13it/s, epoch: 5/5 -  multiclassaccuracy:0.7802083492279053  multiclassprecision:0.7802083492279053  val_multiclassaccuracy:0.1825726181268692  val_multiclassprecision:0.1825726181268692 ]\n"
      ]
     }
    ],
@@ -583,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
之前在Databuilder里，计算`train_step_per_epoch`，需要使用
```
train_step_per_epoch = math.ceil(split / batch_size)
```
需要提前计算数据集的样本数，实际上
```
train_step_per_epoch = len(train_loader)
```
后一种方法的计算更加高效。
