### PR TITLE
refactor:add a simpler implement of step of each epoch based tensorflow

### DIFF
--- a/docs/tutorial/CustomDataLoaderTF.ipynb
+++ b/docs/tutorial/CustomDataLoaderTF.ipynb
@@ -52,10 +52,17 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The version of SecretFlow: 1.2.0.dev20230918\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-04-17 15:18:33,602\tINFO worker.py:1538 -- Started a local Ray instance.\n"
+      "2023-10-02 08:10:32,716\tINFO worker.py:1538 -- Started a local Ray instance.\n"
      ]
     }
    ],
@@ -158,11 +165,18 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-10-02 08:10:35.622369: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Downloading data from https://secretflow-data.oss-accelerate.aliyuncs.com/datasets/tf_flowers/flower_photos.tgz\n",
-      "67588319/67588319 [==============================] - 1s 0us/step\n"
+      "67588319/67588319 [==============================] - 3s 0us/step\n"
      ]
     }
    ],
@@ -214,16 +228,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 436 files belonging to 5 classes.\n",
-      "Using 349 files for training.\n",
-      "Using 87 files for validation.\n"
+      "Found 1201 files belonging to 5 classes.\n",
+      "Using 961 files for training.\n",
+      "Using 240 files for validation.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-04-10 13:16:34.492390: E tensorflow/stream_executor/cuda/cuda_driver.cc:265] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n"
+      "2023-10-02 08:10:40.215033: W tensorflow/core/common_runtime/gpu/gpu_device.cc:1960] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.\n",
+      "Skipping registering GPU devices...\n"
      ]
     }
    ],
@@ -266,7 +281,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'tensorflow.python.data.ops.dataset_ops.BatchDataset'> <class 'tensorflow.python.data.ops.dataset_ops.BatchDataset'>\n"
+      "<class 'tensorflow.python.data.ops.batch_op._BatchDataset'> <class 'tensorflow.python.data.ops.batch_op._BatchDataset'>\n"
      ]
     }
    ],
@@ -323,8 +338,6 @@
     "    batch_size=32,\n",
     "):\n",
     "    def dataset_builder(folder_path, stage=\"train\"):\n",
-    "        import math\n",
-    "\n",
     "        import tensorflow as tf\n",
     "\n",
     "        img_height = 180\n",
@@ -339,11 +352,11 @@
     "        )\n",
     "        if stage == \"train\":\n",
     "            train_dataset = data_set[0]\n",
-    "            train_step_per_epoch = math.ceil(len(data_set[0].file_paths) / batch_size)\n",
+    "            train_step_per_epoch = len(train_dataset)\n",
     "            return train_dataset, train_step_per_epoch\n",
     "        elif stage == \"eval\":\n",
     "            eval_dataset = data_set[1]\n",
-    "            eval_step_per_epoch = math.ceil(len(data_set[1].file_paths) / batch_size)\n",
+    "            eval_step_per_epoch = len(eval_dataset)\n",
     "            return eval_dataset, eval_step_per_epoch\n",
     "\n",
     "    return dataset_builder"
@@ -512,12 +525,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:FL Train Params: {'self': <secretflow.ml.nn.fl.fl_model.FLModel object at 0x7f7b7a28b8e0>, 'x': {alice: '../../public_dataset/datasets/flower_photos', bob: '../../public_dataset/datasets/flower_photos'}, 'y': None, 'batch_size': 32, 'batch_sampling_rate': None, 'epochs': 5, 'verbose': 1, 'callbacks': None, 'validation_data': {alice: '../../public_dataset/datasets/flower_photos', bob: '../../public_dataset/datasets/flower_photos'}, 'shuffle': False, 'class_weight': None, 'sample_weight': None, 'validation_freq': 1, 'aggregate_freq': 2, 'label_decoder': None, 'max_batch_size': 20000, 'prefetch_buffer_size': None, 'sampler_method': 'batch', 'random_seed': 1234, 'dp_spent_step_freq': 1, 'audit_log_dir': None, 'dataset_builder': {alice: <function create_dataset_builder.<locals>.dataset_builder at 0x7f7b7a2bb1f0>, bob: <function create_dataset_builder.<locals>.dataset_builder at 0x7f7b7a2bb0d0>}}\n",
-      "32it [00:18,  1.71it/s, epoch: 1/5 -  loss:1.5339548587799072  accuracy:0.3142559826374054  val_loss:1.582740068435669  val_accuracy:0.2874999940395355 ]\n",
-      "100%|██████████| 8/8 [00:05<00:00,  1.51it/s, epoch: 2/5 -  loss:1.4520319700241089  accuracy:0.36693549156188965  val_loss:1.3319271802902222  val_accuracy:0.40416666865348816 ]\n",
-      "100%|██████████| 8/8 [00:05<00:00,  1.54it/s, epoch: 3/5 -  loss:1.2720597982406616  accuracy:0.45766130089759827  val_loss:1.3382091522216797  val_accuracy:0.47083333134651184 ]\n",
-      "100%|██████████| 8/8 [00:05<00:00,  1.50it/s, epoch: 4/5 -  loss:1.229131817817688  accuracy:0.5040322542190552  val_loss:1.3033963441848755  val_accuracy:0.4375 ]\n",
-      "100%|██████████| 8/8 [00:05<00:00,  1.59it/s, epoch: 5/5 -  loss:1.3306885957717896  accuracy:0.4301075339317322  val_loss:2.1492652893066406  val_accuracy:0.25833332538604736 ]\n"
+      "INFO:root:FL Train Params: {'self': <secretflow.ml.nn.fl.fl_model.FLModel object at 0x7fcb5863edf0>, 'x': {PYURuntime(alice): '/tmp/tmpgqy7z9x_/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpgqy7z9x_/datasets/flower_photos'}, 'y': None, 'batch_size': 32, 'batch_sampling_rate': None, 'epochs': 5, 'verbose': 1, 'callbacks': None, 'validation_data': {PYURuntime(alice): '/tmp/tmpgqy7z9x_/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpgqy7z9x_/datasets/flower_photos'}, 'shuffle': False, 'class_weight': None, 'sample_weight': None, 'validation_freq': 1, 'aggregate_freq': 2, 'label_decoder': None, 'max_batch_size': 20000, 'prefetch_buffer_size': None, 'sampler_method': 'batch', 'random_seed': 1234, 'dp_spent_step_freq': 1, 'audit_log_dir': None, 'dataset_builder': {PYURuntime(alice): <function create_dataset_builder.<locals>.dataset_builder at 0x7fcb8a047430>, PYURuntime(bob): <function create_dataset_builder.<locals>.dataset_builder at 0x7fcb8a047160>}, 'wait_steps': 100}\n",
+      "32it [00:15,  2.06it/s, epoch: 1/5 -  loss:1.5347011089324951  accuracy:0.3132154047489166  val_loss:1.5676387548446655  val_accuracy:0.2874999940395355 ]\n",
+      " 26%|██▌       | 8/31 [00:02<00:07,  3.04it/s]"
      ]
     }
    ],
@@ -565,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial/CustomDataLoaderTF.ipynb
+++ b/docs/tutorial/CustomDataLoaderTF.ipynb
@@ -527,7 +527,10 @@
      "text": [
       "INFO:root:FL Train Params: {'self': <secretflow.ml.nn.fl.fl_model.FLModel object at 0x7fcb5863edf0>, 'x': {PYURuntime(alice): '/tmp/tmpgqy7z9x_/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpgqy7z9x_/datasets/flower_photos'}, 'y': None, 'batch_size': 32, 'batch_sampling_rate': None, 'epochs': 5, 'verbose': 1, 'callbacks': None, 'validation_data': {PYURuntime(alice): '/tmp/tmpgqy7z9x_/datasets/flower_photos', PYURuntime(bob): '/tmp/tmpgqy7z9x_/datasets/flower_photos'}, 'shuffle': False, 'class_weight': None, 'sample_weight': None, 'validation_freq': 1, 'aggregate_freq': 2, 'label_decoder': None, 'max_batch_size': 20000, 'prefetch_buffer_size': None, 'sampler_method': 'batch', 'random_seed': 1234, 'dp_spent_step_freq': 1, 'audit_log_dir': None, 'dataset_builder': {PYURuntime(alice): <function create_dataset_builder.<locals>.dataset_builder at 0x7fcb8a047430>, PYURuntime(bob): <function create_dataset_builder.<locals>.dataset_builder at 0x7fcb8a047160>}, 'wait_steps': 100}\n",
       "32it [00:15,  2.06it/s, epoch: 1/5 -  loss:1.5347011089324951  accuracy:0.3132154047489166  val_loss:1.5676387548446655  val_accuracy:0.2874999940395355 ]\n",
-      " 26%|██▌       | 8/31 [00:02<00:07,  3.04it/s]"
+      "32it [00:13,  2.34it/s, epoch: 2/5 -  loss:1.2867189645767212  accuracy:0.45378851890563965  val_loss:2.0703980922698975  val_accuracy:0.2708333432674408 ]\n",
+      "32it [00:13,  2.33it/s, epoch: 3/5 -  loss:1.4517239332199097  accuracy:0.43213987350463867  val_loss:1.3848860263824463  val_accuracy:0.4749999940395355 ]\n",
+      "32it [00:12,  2.50it/s, epoch: 4/5 -  loss:1.048319935798645  accuracy:0.6053289175033569  val_loss:1.3072837591171265  val_accuracy:0.4333333373069763 ]\n",
+      "32it [00:12,  2.55it/s, epoch: 5/5 -  loss:0.9443800449371338  accuracy:0.6203163862228394  val_loss:1.3488250970840454  val_accuracy:0.44999998807907104 ]\n"
      ]
     }
    ],


### PR DESCRIPTION
之前在Databuilder里，计算`train_step_per_epoch`，需要使用
```
math.ceil(len(data_set[0].file_paths) / batch_size)
```
需要提前计算数据集的样本数，实际上
```
train_step_per_epoch = len(data_set[0])
```
后一种方法的计算更加高效。
`eval_dataset ` 也类似
同时解决中 https://github.com/secretflow/secretflow/issues/748 提到数据集封装的问题