### PR TITLE
【OSCP】在 SecretFlow 拆分学习中实现 Direction-based scoring 攻击

### DIFF
--- a/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
+++ b/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
@@ -69,26 +69,26 @@ class DirectionBasedScoringAttack(AttackCallback):
             return
 
         def record_gradient(worker: SLBaseTorchModel):
-            if 'grad_lia_attack' not in worker._callback_store:
-                worker._callback_store['grad_lia_attack'] = {}
+            if 'direction_based_lia_attack' not in worker._callback_store:
+                worker._callback_store['direction_based_lia_attack'] = {}
             if isinstance(worker._gradient, list):
                 grad = torch.stack(worker._gradient).cpu().numpy()
             else:
                 grad = worker._gradient.cpu().numpy()
             if batch == 0:
                 num_feature = grad.shape[1]
-                worker._callback_store['grad_lia_attack']['grads'] = np.empty(
+                worker._callback_store['direction_based_lia_attack']['grads'] = np.empty(
                     (0, num_feature)
                 )
-            worker._callback_store['grad_lia_attack']['grads'] = np.append(
-                worker._callback_store['grad_lia_attack']['grads'],
+            worker._callback_store['direction_based_lia_attack']['grads'] = np.append(
+                worker._callback_store['direction_based_lia_attack']['grads'],
                 grad,
                 axis=0,
             )
 
         def record_label(worker: SLBaseTorchModel):
-            if 'grad_lia_attack' not in worker._callback_store:
-                worker._callback_store['grad_lia_attack'] = {}
+            if 'direction_based_lia_attack' not in worker._callback_store:
+                worker._callback_store['direction_based_lia_attack'] = {}
 
             if isinstance(worker.train_y, list):
                 # several batch
@@ -105,9 +105,9 @@ class DirectionBasedScoringAttack(AttackCallback):
                 # convert the one hot encoded label to the category index
                 label = np.argmax(label, axis=1, keepdims=True)
             if batch == 0:
-                worker._callback_store['grad_lia_attack']['labels'] = np.empty((0, 1))
-            worker._callback_store['grad_lia_attack']['labels'] = np.append(
-                worker._callback_store['grad_lia_attack']['labels'], label, axis=0
+                worker._callback_store['direction_based_lia_attack']['labels'] = np.empty((0, 1))
+            worker._callback_store['direction_based_lia_attack']['labels'] = np.append(
+                worker._callback_store['direction_based_lia_attack']['labels'], label, axis=0
             )
 
         self._workers[self.attack_party].apply(record_gradient)
@@ -118,7 +118,7 @@ class DirectionBasedScoringAttack(AttackCallback):
             return
         label_targets = reveal(
             self._workers[self.label_party].apply(
-                lambda worker: worker._callback_store['grad_lia_attack']['labels']
+                lambda worker: worker._callback_store['direction_based_lia_attack']['labels']
             )
         )
 
@@ -138,7 +138,7 @@ class DirectionBasedScoringAttack(AttackCallback):
     @staticmethod
     def direction_based_scoring(worker, positive_index):
         # compute cosine similarity with grad and grads.
-        grad = worker._callback_store['grad_lia_attack']['grads']
+        grad = worker._callback_store['direction_based_lia_attack']['grads']
 
         positive_grad = grad[positive_index]
         positive_grad = torch.tensor(positive_grad)

--- a/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
+++ b/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
@@ -1,0 +1,181 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn.cluster import SpectralClustering
+from sklearn.metrics import accuracy_score, precision_score, recall_score, roc_auc_score
+from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.preprocessing import OneHotEncoder
+
+from secretflow.device import PYU, reveal
+from secretflow.ml.nn.callbacks.attack import AttackCallback
+from secretflow.ml.nn.sl.backend.torch.sl_base import SLBaseTorchModel
+
+
+class DirectionBasedScoringAttack(AttackCallback):
+    """
+    Implemention of Directio-based Scoring Attack in Vertical Federated Learning: https://arxiv.org/pdf/2102.08504.
+    Direction-based scoring function: Given the gradient of a positive example,
+    the attacker can infer labels by calculating the cosine similarity between
+    this gradient and the gradients of other samples with unknown labels.
+
+    Args:
+        attack_party: The attack party who does not have label.
+        label_party: The party holds label.
+        num_classes: The model classes number.
+    """
+
+    def __init__(
+        self,
+        attack_party: PYU,
+        label_party: PYU,
+        num_classes: int,
+        **params,
+    ):
+        super().__init__(
+            **params,
+        )
+        self.attack_party = attack_party
+        self.label_party = label_party
+        self.num_classes = num_classes
+        self.last_epoch = False
+        self.positive_grad = None
+        self.attack_logs = {}
+        self.is_batch = False
+
+    def on_epoch_begin(self, epoch=None, logs=None):
+        # The attacker uses the method during the final epoch.
+        if epoch == self.params['epochs'] - 1:
+            self.last_epoch = True
+
+    def on_train_batch_end(self, batch):
+        # The attacker knows the label or index of a positive sample.
+        # Let's assume that this sample appears in the first batch.
+        if not self.last_epoch:
+            return
+
+        def record_gradient(worker: SLBaseTorchModel):
+            if 'grad_lia_attack' not in worker._callback_store:
+                worker._callback_store['grad_lia_attack'] = {}
+            if isinstance(worker._gradient, list):
+                grad = torch.stack(worker._gradient).cpu().numpy()
+            else:
+                grad = worker._gradient.cpu().numpy()
+            if batch == 0:
+                num_feature = grad.shape[1]
+                worker._callback_store['grad_lia_attack']['grads'] = np.empty(
+                    (0, num_feature)
+                )
+            worker._callback_store['grad_lia_attack']['grads'] = np.append(
+                worker._callback_store['grad_lia_attack']['grads'],
+                grad,
+                axis=0,
+            )
+
+        def record_label(worker: SLBaseTorchModel):
+            if 'grad_lia_attack' not in worker._callback_store:
+                worker._callback_store['grad_lia_attack'] = {}
+
+            if isinstance(worker.train_y, list):
+                # several batch
+                label = worker.train_y[0].cpu().numpy()
+            else:
+                # only one batch
+                label = worker.train_y.cpu().numpy()
+
+            # process the label shape to dim = 2
+            if len(label.shape) == 1:
+                label = label[:, np.newaxis]
+            assert len(label.shape) == 2
+            if self.num_classes > 2 and label.shape[1] > 1:
+                # convert the one hot encoded label to the category index
+                label = np.argmax(label, axis=1, keepdims=True)
+            if batch == 0:
+                worker._callback_store['grad_lia_attack']['labels'] = np.empty((0, 1))
+            worker._callback_store['grad_lia_attack']['labels'] = np.append(
+                worker._callback_store['grad_lia_attack']['labels'], label, axis=0
+            )
+
+        self._workers[self.attack_party].apply(record_gradient)
+        self._workers[self.label_party].apply(record_label)
+
+    def on_epoch_end(self, epoch=None, logs=None):
+        if not self.last_epoch:
+            return
+        label_targets = reveal(
+            self._workers[self.label_party].apply(
+                lambda worker: worker._callback_store['grad_lia_attack']['labels']
+            )
+        )
+
+        index = np.argmax(label_targets == 1)
+        cluster_labels = self._workers[self.attack_party].apply(
+            self.direction_based_scoring,
+            positive_index=index,
+        )
+        # reveal only for compute attack acc.
+        cluster_labels: List = reveal(cluster_labels)
+
+        self.record_metrics(cluster_labels, label_targets)
+
+    def get_attack_metrics(self):
+        return self.attack_logs
+
+    @staticmethod
+    def direction_based_scoring(worker, positive_index):
+        # compute cos similarity with grad and grads.
+        grad = worker._callback_store['grad_lia_attack']['grads']
+
+        positive_grad = grad[positive_index]
+        positive_grad = torch.tensor(positive_grad)
+        _grad = torch.tensor(grad)
+
+        vector_expanded = positive_grad.unsqueeze(0).expand_as(_grad)
+        cosine_similarities = F.cosine_similarity(vector_expanded, _grad, dim=1)
+        attack_predict = (cosine_similarities > 0).float()
+
+        label_preds = []
+        label_preds += list(attack_predict.cpu().numpy())
+
+        return label_preds
+
+    def record_metrics(self, label_preds: np.ndarray, label_targets: np.ndarray):
+        multi_class = 'raise'
+        average = 'binary'
+        if self.num_classes > 2:
+            if len(label_targets.shape) == 1:
+                label_targets = label_targets.reshape(-1, 1)
+            if len(label_preds.shape) == 1:
+                label_preds = label_preds.reshape(-1, 1)
+            enc = OneHotEncoder(categories=[range(self.num_classes)], sparse=False)
+            label_targets = enc.fit_transform(label_targets)
+            label_preds = enc.fit_transform(label_preds)
+            multi_class = 'ovo'
+            average = "weighted"
+        if np.all(label_targets == 0) or np.all(label_targets == 1):
+            self.attack_logs['attack_auc'] = -1
+        else:
+            self.attack_logs['attack_auc'] = roc_auc_score(
+                label_targets, label_preds, multi_class=multi_class
+            )
+        self.attack_logs['attack_acc'] = accuracy_score(label_targets, label_preds)
+        self.attack_logs['attack_recall'] = recall_score(
+            label_targets, label_preds, average=average
+        )
+        self.attack_logs['attack_precision'] = precision_score(
+            label_targets, label_preds, average=average
+        )

--- a/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
+++ b/secretflow/ml/nn/sl/attacks/direction_based_scoring_torch.py
@@ -137,7 +137,7 @@ class DirectionBasedScoringAttack(AttackCallback):
 
     @staticmethod
     def direction_based_scoring(worker, positive_index):
-        # compute cos similarity with grad and grads.
+        # compute cosine similarity with grad and grads.
         grad = worker._callback_store['grad_lia_attack']['grads']
 
         positive_grad = grad[positive_index]

--- a/tests/ml/nn/sl/attack/model_def.py
+++ b/tests/ml/nn/sl/attack/model_def.py
@@ -402,10 +402,8 @@ class WideDeepFuse(nn.Module):
         self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False)
 
     def forward(self, X):
-        X = torch.cat(X, dim=1)
-        logit = X[:, -1:]
-
-        dnn_logit = self.dnn_linear(X[:, :128])
+        logit = X[1]
+        dnn_logit = self.dnn_linear(X[0])
         _logit = dnn_logit + logit
         y_pred = torch.sigmoid(_logit)
         return y_pred

--- a/tests/ml/nn/sl/attack/model_def.py
+++ b/tests/ml/nn/sl/attack/model_def.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -259,3 +261,260 @@ class BottomModelPlus(nn.Module):
         x = self.fc_final(x)
 
         return x
+
+
+class WideDeepBase(nn.Module):
+    def __init__(
+        self,
+        inputs_dim,
+        hidden_units,
+        dropout_rate,
+    ):
+        super(WideDeepBase, self).__init__()
+        self.inputs_dim = inputs_dim
+        self.hidden_units = hidden_units
+        self.dropout = nn.Dropout(dropout_rate)
+
+        self.hidden_units = [inputs_dim] + list(self.hidden_units)
+        self.linear = nn.ModuleList(
+            [
+                nn.Linear(self.hidden_units[i], self.hidden_units[i + 1])
+                for i in range(len(self.hidden_units) - 1)
+            ]
+        )
+        for name, tensor in self.linear.named_parameters():
+            if 'weight' in name:
+                nn.init.normal_(tensor, mean=0, std=0.0001)
+
+        self.activation = nn.ReLU()
+
+    def forward(self, X):
+        inputs = X
+        for i in range(len(self.linear)):
+            fc = self.linear[i](inputs)
+            fc = self.activation(fc)
+            fc = self.dropout(fc)
+            inputs = fc
+        return inputs
+
+
+class WideDeepBottomAlice(nn.Module):
+    def __init__(
+        self,
+        feat_size,
+        embedding_size,
+        linear_feature_columns,
+        dnn_feature_columns,
+        use_attention=True,
+        attention_factor=8,
+        l2_reg=0.00001,
+        drop_rate=0.9,
+        dnn_hidden_units=(256, 128),
+    ):
+        super(WideDeepBottomAlice, self).__init__()
+        self.sparse_feature_columns = list(
+            filter(lambda x: x[1] == 'sparse', dnn_feature_columns)
+        )
+        self.embedding_dic = nn.ModuleDict(
+            {
+                feat[0]: nn.Embedding(feat_size[feat[0]], embedding_size, sparse=False)
+                for feat in self.sparse_feature_columns
+            }
+        )
+        self.dense_feature_columns = list(
+            filter(lambda x: x[1] == 'dense', dnn_feature_columns)
+        )
+
+        self.feature_index = defaultdict(int)
+        start = 0
+        for feat in feat_size:
+            self.feature_index[feat] = start
+            start += 1
+
+        self.dnn = WideDeepBase(
+            len(self.dense_feature_columns) + embedding_size * len(self.embedding_dic),
+            dnn_hidden_units,
+            0.5,
+        )
+
+        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False)
+
+        dnn_hidden_units = [len(feat_size), 1]
+        self.linear = nn.ModuleList(
+            [
+                nn.Linear(dnn_hidden_units[i], dnn_hidden_units[i + 1])
+                for i in range(len(dnn_hidden_units) - 1)
+            ]
+        )
+        for name, tensor in self.linear.named_parameters():
+            if 'weight' in name:
+                nn.init.normal_(tensor, mean=0, std=0.00001)
+
+        self.out = nn.Sigmoid()
+        self.act = nn.ReLU()
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, X):
+
+        sparse_embedding = [
+            self.embedding_dic[feat[0]](
+                torch.clamp(X[:, self.feature_index[feat[0]]].long(), min=0)
+            ).reshape(X.shape[0], 1, -1)
+            for feat in self.sparse_feature_columns
+        ]
+        sparse_input = torch.cat(sparse_embedding, dim=1)
+        sparse_input = torch.flatten(sparse_input, start_dim=1)
+        dense_values = [
+            X[:, self.feature_index[feat[0]]].reshape(-1, 1)
+            for feat in self.dense_feature_columns
+        ]
+        dense_input = torch.cat(dense_values, dim=1)
+        dnn_input = torch.cat((sparse_input, dense_input), dim=1)
+        dnn_out = self.dnn(dnn_input)
+        return dnn_out
+
+    def output_num(self):
+        return 1
+
+
+class WideDeepBottomBob(nn.Module):
+    def __init__(
+        self,
+        feat_size,
+        embedding_size,
+        linear_feature_columns,
+        dnn_feature_columns,
+        use_attention=True,
+        attention_factor=8,
+        l2_reg=0.00001,
+        drop_rate=0.9,
+        dnn_hidden_units=(256, 128),
+    ):
+        super(WideDeepBottomBob, self).__init__()
+        self.sparse_feature_columns = list(
+            filter(lambda x: x[1] == 'sparse', dnn_feature_columns)
+        )
+        self.embedding_dic = nn.ModuleDict(
+            {
+                feat[0]: nn.Embedding(feat_size[feat[0]], embedding_size, sparse=False)
+                for feat in self.sparse_feature_columns
+            }
+        )
+        self.dense_feature_columns = list(
+            filter(lambda x: x[1] == 'dense', dnn_feature_columns)
+        )
+
+        self.feature_index = defaultdict(int)
+        start = 0
+        for feat in feat_size:
+            self.feature_index[feat] = start
+            start += 1
+
+        self.dnn = WideDeepBase(
+            len(self.dense_feature_columns) + embedding_size * len(self.embedding_dic),
+            dnn_hidden_units,
+            0.5,
+        )
+
+        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False)
+
+        dnn_hidden_units = [len(feat_size), 1]
+        self.linear = nn.ModuleList(
+            [
+                nn.Linear(dnn_hidden_units[i], dnn_hidden_units[i + 1])
+                for i in range(len(dnn_hidden_units) - 1)
+            ]
+        )
+        for name, tensor in self.linear.named_parameters():
+            if 'weight' in name:
+                nn.init.normal_(tensor, mean=0, std=0.00001)
+
+        self.out = nn.Sigmoid()
+        self.act = nn.ReLU()
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, X):
+
+        # wide
+        X = X.float()
+        logit = X
+        # print(X.dtype)
+        for i in range(len(self.linear)):
+            fc = self.linear[i](logit)
+            fc = self.act(fc)
+            fc = self.dropout(fc)
+            logit = fc
+
+        return logit
+
+    def output_num(self):
+        return 1
+
+
+class WideDeepFuse(nn.Module):
+    # 只包含DNN
+    def __init__(
+        self,
+        feat_size,
+        embedding_size,
+        linear_feature_columns,
+        dnn_feature_columns,
+        use_attention=True,
+        attention_factor=8,
+        l2_reg=0.00001,
+        drop_rate=0.9,
+        dnn_hidden_units=(256, 128),
+    ):
+        super(WideDeepFuse, self).__init__()
+        self.sparse_feature_columns = list(
+            filter(lambda x: x[1] == 'sparse', dnn_feature_columns)
+        )
+        self.embedding_dic = nn.ModuleDict(
+            {
+                feat[0]: nn.Embedding(feat_size[feat[0]], embedding_size, sparse=False)
+                for feat in self.sparse_feature_columns
+            }
+        )
+        self.dense_feature_columns = list(
+            filter(lambda x: x[1] == 'dense', dnn_feature_columns)
+        )
+
+        self.feature_index = defaultdict(int)
+        start = 0
+        for feat in feat_size:
+            self.feature_index[feat] = start
+            start += 1
+
+        self.dnn = WideDeepBase(
+            len(self.dense_feature_columns) + embedding_size * len(self.embedding_dic),
+            dnn_hidden_units,
+            0.5,
+        )
+
+        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False)
+
+        dnn_hidden_units = [len(feat_size), 1]
+        self.linear = nn.ModuleList(
+            [
+                nn.Linear(dnn_hidden_units[i], dnn_hidden_units[i + 1])
+                for i in range(len(dnn_hidden_units) - 1)
+            ]
+        )
+        for name, tensor in self.linear.named_parameters():
+            if 'weight' in name:
+                nn.init.normal_(tensor, mean=0, std=0.00001)
+
+        self.out = nn.Sigmoid()
+        self.act = nn.ReLU()
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, X):
+
+        # wide
+        # print("Fuse model input shape", X.shape)
+        logit = X[:, -2:-1]
+
+        dnn_logit = self.dnn_linear(X[:, :128])
+        _logit = dnn_logit + logit
+        y_pred = torch.sigmoid(_logit)
+        return y_pred

--- a/tests/ml/nn/sl/attack/model_def.py
+++ b/tests/ml/nn/sl/attack/model_def.py
@@ -385,7 +385,6 @@ class WideDeepBottomBob(nn.Module):
             fc = self.act(fc)
             fc = self.dropout(fc)
             logit = fc
-
         return logit
 
     def output_num(self):
@@ -403,7 +402,8 @@ class WideDeepFuse(nn.Module):
         self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False)
 
     def forward(self, X):
-        logit = X[:, -2:-1]
+        X = torch.cat(X, dim=1)
+        logit = X[:, -1:]
 
         dnn_logit = self.dnn_linear(X[:, :128])
         _logit = dnn_logit + logit

--- a/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
+++ b/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
@@ -44,7 +44,7 @@ def test_direct_based_scoring_lia(sf_simulation_setup_devices):
     bob = sf_simulation_setup_devices.bob
 
     random_state = 1234
-    num_samples = 4100
+    num_samples = 200
     # the number for testing purposes. For more details about the dataset, please refer to the code in secretflow.utils.simulation.datasets
 
     sparse_feature = [

--- a/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
+++ b/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
@@ -134,7 +134,6 @@ def test_direct_based_scoring_lia(sf_simulation_setup_devices):
         alice: base_model_alice,
         bob: base_model_bob,
     }
-    agg_method = Concat(axis=1)
     sl_model = SLModel(
         base_model_dict=base_model_dict,
         device_y=bob,
@@ -143,7 +142,6 @@ def test_direct_based_scoring_lia(sf_simulation_setup_devices):
         random_seed=1234,
         strategy="split_nn",
         backend="torch",
-        agg_method=agg_method,
     )
 
     direction_lia = DirectionBasedScoringAttack(attack_party=alice, label_party=bob)

--- a/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
+++ b/tests/ml/nn/sl/attack/test_torch_direct_based_scoring_lia.py
@@ -1,0 +1,178 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.preprocessing import LabelEncoder, MinMaxScaler
+from torchmetrics import AUROC, Accuracy
+
+import secretflow as sf
+from secretflow.data.split import train_test_split
+from secretflow.ml.nn import SLModel
+from secretflow.ml.nn.applications.sl_dnn_torch import DnnBase, DnnFuse
+from secretflow.ml.nn.core.torch import TorchModel, metric_wrapper, optim_wrapper
+from secretflow.ml.nn.sl.agglayer.agg_method import Concat
+from secretflow.ml.nn.sl.attacks.direction_based_scoring_torch import (
+    DirectionBasedScoringAttack,
+)
+from secretflow.preprocessing import StandardScaler
+from secretflow.utils.simulation.data.dataframe import create_df
+from secretflow.utils.simulation.datasets import load_criteo_unpartitioned
+from tests.ml.nn.sl.attack.model_def import (
+    WideDeepBottomAlice,
+    WideDeepBottomBob,
+    WideDeepFuse,
+)
+
+
+def test_direct_based_scoring_lia(sf_simulation_setup_devices):
+    alice = sf_simulation_setup_devices.alice
+    bob = sf_simulation_setup_devices.bob
+
+    random_state = 1234
+    num_samples = 4100
+    # the number for testing purposes. For more details about the dataset, please refer to the code in secretflow.utils.simulation.datasets
+
+    sparse_feature = [
+        'C' + str(i) for i in range(1, 27)
+    ]  # C represents categorical features
+    dense_feature = [
+        'I' + str(i) for i in range(1, 14)
+    ]  # I represents numerical features
+    df = load_criteo_unpartitioned(num_samples)
+    df[sparse_feature] = df[sparse_feature].fillna(
+        '-1',
+    )
+    df[dense_feature] = df[dense_feature].fillna(
+        '0',
+    )
+
+    feat_sizes = {}
+    feat_sizes_dense = {feat: 1 for feat in dense_feature}
+    feat_sizes_sparse = {feat: len(df[feat].unique()) for feat in sparse_feature}
+    feat_sizes.update(feat_sizes_dense)
+    feat_sizes.update(feat_sizes_sparse)
+    for feat in sparse_feature:
+        lbe = LabelEncoder()
+        df[feat] = lbe.fit_transform(df[feat])
+    nms = MinMaxScaler(feature_range=(0, 1))
+    df[dense_feature] = nms.fit_transform(df[dense_feature])
+
+    fixlen_feature_columns = [(feat, 'sparse') for feat in sparse_feature] + [
+        (feat, 'dense') for feat in dense_feature
+    ]
+    dnn_feature_columns = fixlen_feature_columns
+    linear_feature_columns = fixlen_feature_columns
+
+    # Split the Dataset as the settings in the paper
+    data = create_df(
+        source=df,
+        parts={
+            alice: (1, 40),
+            bob: (1, 40),
+        },
+        axis=1,
+        shuffle=False,
+        aggregator=None,
+        comparator=None,
+    )
+    label = create_df(
+        source=df,
+        parts={bob: (0, 1)},
+        axis=1,
+        shuffle=False,
+        aggregator=None,
+        comparator=None,
+    ).astype(np.float32)
+    scaler = StandardScaler()
+    data = scaler.fit_transform(data).astype("int64")
+    train_data, test_data = train_test_split(
+        data, train_size=0.8, random_state=random_state
+    )
+    train_label, test_label = train_test_split(
+        label, train_size=0.8, random_state=random_state
+    )
+
+    metrics = [
+        metric_wrapper(Accuracy, task="binary"),
+        metric_wrapper(AUROC, task="binary"),
+    ]
+    dnn_feature_columns = fixlen_feature_columns
+    linear_feature_columns = fixlen_feature_columns
+    embedding_size = 12
+
+    base_model_alice = TorchModel(
+        model_fn=WideDeepBottomAlice,
+        optim_fn=optim_wrapper(torch.optim.Adam, lr=1e-3),
+        feat_size=feat_sizes,
+        embedding_size=embedding_size,
+        linear_feature_columns=linear_feature_columns,
+        dnn_feature_columns=dnn_feature_columns,
+    )
+
+    base_model_bob = TorchModel(
+        model_fn=WideDeepBottomBob,
+        optim_fn=optim_wrapper(torch.optim.Adam, lr=1e-3),
+        feat_size=feat_sizes,
+        embedding_size=embedding_size,
+        linear_feature_columns=linear_feature_columns,
+        dnn_feature_columns=dnn_feature_columns,
+    )
+
+    fuse_model = TorchModel(
+        model_fn=WideDeepFuse,
+        loss_fn=nn.BCELoss,
+        optim_fn=optim_wrapper(torch.optim.Adam, lr=1e-3),
+        metrics=metrics,
+        feat_size=feat_sizes,
+        embedding_size=embedding_size,
+        linear_feature_columns=linear_feature_columns,
+        dnn_feature_columns=dnn_feature_columns,
+    )
+
+    base_model_dict = {
+        alice: base_model_alice,
+        bob: base_model_bob,
+    }
+    agg_method = Concat(axis=1)
+    sl_model = SLModel(
+        base_model_dict=base_model_dict,
+        device_y=bob,
+        model_fuse=fuse_model,
+        simulation=True,
+        random_seed=1234,
+        strategy="split_nn",
+        backend="torch",
+        agg_method=agg_method,
+    )
+
+    direction_lia = DirectionBasedScoringAttack(
+        attack_party=alice, label_party=bob, num_classes=2
+    )
+    history = sl_model.fit(
+        train_data,
+        train_label,
+        validation_data=(test_data, test_label),
+        epochs=1,
+        batch_size=128,
+        shuffle=False,
+        random_seed=1234,
+        callbacks=[direction_lia],
+    )
+    attack_metrics = direction_lia.get_attack_metrics()
+    assert 'attack_acc' in attack_metrics
+    print(attack_metrics)


### PR DESCRIPTION
**Type of change**
fixed: #1238
- [ ] Add new papers (Please tell us why you think this paper is awesome!)
- [ ] Fix the category of an existing paper/papers (Please tell us the reasons)
- [x] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**

> This PR introduces the [direction-based scoring attack](https://arxiv.org/pdf/2102.08504.) into SecretFlow. The attack is a label inference attack for Vertical Federated Learning or Split Learning. By analyzing the direction of gradients, the attacker can infer labels by calculating the cosine similarity between the gradient of a sample with a known label and the gradients of other samples with unknown labels.

**Result**
We tested the code using the Criteo dataset and the Wide & Deep model, with settings similar to those described in the paper. The result is shown as follows:
![image](https://github.com/secretflow/secretflow/assets/49605058/6bf297e2-f806-49dc-a431-a876830f5385)

