### PR TITLE
使用隐语实现差分隐私联邦学习FedSMP

### DIFF
--- a/examples/security/h_gia/FedSMP_defense/FedSMP_torch.py
+++ b/examples/security/h_gia/FedSMP_defense/FedSMP_torch.py
@@ -1,0 +1,183 @@
+# Copyright xuxiaoyang, ywenrou123@163.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from typing import Tuple
+
+import numpy as np
+import torch
+
+from secretflow import wait
+from secretflow.device import PYU, DeviceObject, PYUObject
+from secretflow_fl.ml.nn.callbacks.callback import Callback
+from secretflow_fl.ml.nn.core.torch import BuilderType
+from secretflow_fl.ml.nn.fl.backend.torch.fl_base import BaseTorchModel
+from secretflow_fl.ml.nn.fl.strategy_dispatcher import register_strategy
+from secretflow_fl.security.privacy.mechanism.mechanism_fl import GaussianModelDP
+
+
+# the client strategy in FedSMP
+class FedSMP(BaseTorchModel):
+    """
+    Implemention of FedSMP algorithm in paper Federated Learning with Sparsified Model Perturbation: Improving Accuracy under Client-Level Differential Privacy: https://ieeexplore.ieee.org/abstract/document/10360319/.
+
+    FedSMP is a novel differentially-private FL scheme which can provide a client-level DP guarantee while maintaining high model accuracy. To mitigate the impact of privacy protection on model accuracy, Fed-SMP leverages a new technique called Sparsified Model Perturbation (SMP) where local models are sparsified first before being perturbed by Gaussian noise.
+    """
+
+    def __init__(
+        self,
+        builder_base: BuilderType,
+        random_seed: int = None,
+        skip_bn: bool = False,
+        **kwargs,
+    ):
+        super().__init__(builder_base, random_seed=random_seed, skip_bn=skip_bn)
+
+        self.grad_mask = None
+        self.compression_ratio = 1.0
+        self.noise_multiplier = kwargs.get("noise_multiplier", 0.0)
+        self.l2_norm_clip = kwargs.get("l2_norm_clip", 10000)
+        self.num_clients = kwargs.get("num_clients", 1)
+
+    def train_step(
+        self,
+        weights: np.ndarray,
+        cur_steps: int,
+        train_steps: int,
+        **kwargs,
+    ) -> Tuple[np.ndarray, int]:
+        """Accept ps model params, then do local train
+
+        Args:
+            weights: global weight from params server
+            cur_steps: current train step
+            train_steps: local training steps
+            kwargs: strategy-specific parameters
+        Returns:
+            Parameters after local training
+        """
+        assert self.model is not None, "Model cannot be none, please give model define"
+        self.model.train()
+        refresh_data = kwargs.get("refresh_data", False)
+        if refresh_data:
+            self._reset_data_iter()
+        if weights is not None:
+            self.set_weights(weights)
+
+        # copy the model weights before local training
+        init_weights = copy.deepcopy(self.get_weights(return_numpy=True))
+
+        # local training
+        num_sample = 0
+        dp_strategy = kwargs.get("dp_strategy", None)
+        logs = {}
+        loss: torch.Tensor = None
+
+        for step in range(train_steps):
+            x, y, s_w = self.next_batch()
+            num_sample += x.shape[0]
+
+            loss = self.model.training_step((x, y), cur_steps + step, sample_weight=s_w)
+
+            if self.model.automatic_optimization:
+                self.model.backward_step(loss)
+
+        loss_value = loss.item()
+        logs["train-loss"] = loss_value
+
+        self.logs = self.transform_metrics(logs)
+        self.wrapped_metrics.extend(self.wrap_local_metrics())
+        self.epoch_logs = copy.deepcopy(self.logs)
+
+        model_weights = self.get_weights(return_numpy=True)
+
+        # FedSMP DP operation
+        grads = [v2 - v1 for v1, v2 in zip(init_weights, model_weights)]
+
+        # add mask to sparsify the grads
+        grads = [v2 * v1 for v1, v2 in zip(grads, self.grad_mask)]
+        grads = [v / self.compression_ratio for v in grads]
+
+        # add noise
+        model_gdp = GaussianModelDP(
+            noise_multiplier=self.noise_multiplier,
+            num_clients=self.num_clients,
+            l2_norm_clip=self.l2_norm_clip,
+        )
+        grads = model_gdp(grads)
+
+        # add mask to the grads after the noise injection
+        grads = [v2 * v1 for v1, v2 in zip(grads, self.grad_mask)]
+
+        model_weights = [v1 + v2 for v1, v2 in zip(init_weights, grads)]
+
+        return model_weights, num_sample
+
+    def apply_weights(self, weights, **kwargs):
+        """Accept ps model params, then update local model
+
+        Args:
+            weights: global weight from params server
+        """
+        if weights is not None:
+            self.set_weights(weights)
+
+
+@register_strategy(strategy_name='fed_smp', backend='torch')
+class PYUFedSMP(FedSMP):
+    pass
+
+
+# the operations of the server in FedSMP
+class FedSMPServerCallback(Callback):
+    def __init__(self, server, compression_ratio, global_net, **kwargs):
+        super().__init__(**kwargs)
+        self.server = server
+        self.compression_ratio = compression_ratio
+        self.global_net = global_net
+
+    def on_train_batch_begin(self, batch):
+
+        # the server generate the grad mask
+        def generate_grad_mask(compression_ratio, params) -> PYUObject:
+            def _generate_grad_mask(p, params):
+                mask = []
+                for k, v in params.items():
+                    submask = np.random.binomial(
+                        n=1, p=1 - compression_ratio, size=v.shape
+                    )
+                    mask.append(submask)
+
+                return mask
+
+            return self.server(_generate_grad_mask)(compression_ratio, params)
+
+        grad_mask = generate_grad_mask(
+            self.compression_ratio, self.global_net.state_dict()
+        )
+
+        # send grad mask to all clients
+        def receive_grad_mask(worker: BaseTorchModel, grad_mask, compression_ratio):
+            worker.grad_mask = grad_mask
+            worker.compression_ratio = compression_ratio
+            return
+
+        for device, worker in self._workers.items():
+            wait(
+                worker.apply(
+                    receive_grad_mask, grad_mask.to(device), self.compression_ratio
+                )
+            )
+
+        return

--- a/examples/security/h_gia/FedSMP_defense/README.md
+++ b/examples/security/h_gia/FedSMP_defense/README.md
@@ -1,0 +1,30 @@
+# Introduction
+
+The implemention of FedSMP, a differentially private federated learning scheme.
+
+[Federated Learning with Sparsified Model Perturbation (FedSMP): Improving Accuracy under Client-Level Differential Privacy](https://ieeexplore.ieee.org/abstract/document/10360319/)
+
+## Algorithm Description
+
+FedSMP is a novel differentially-private FL scheme which can provide a client-level DP guarantee while maintaining high model accuracy. To mitigate the impact of privacy protection on model accuracy, Fed-SMP leverages a new technique called Sparsified Model Perturbation (SMP) where local models are sparsified first before being perturbed by Gaussian noise.
+
+In each round of FL learning, FedSMP includs the following steps:
+
+1. the server:
+
+    - generates a random mask vector $m\in\{0,1\}^d$ with a compression ratio $p=1-\frac{k}{d}$, where $k$ is the total number of element $1$ in $m\in\{0,1\}^d$
+
+2. the clients:
+
+    - conduct local training to obatin the model updates $g$
+    - mask the model updates $g=g*m$
+    - scale up the model updats $g=g*\frac{d}{k}$
+    - inject Gaussian noise $g=g+\mathcal{N}(0,\frac{\sigma^2C^2I^d}{N})$
+    - mask the model updates $g=g*m$
+
+3. the server:
+    - aggregate the model updates with DP noise
+
+## Test
+
+`pytest --env sim -n auto -v --capture=no tests/ml/nn/fl/strategy/test_fedsmp_torch.py`

--- a/secretflow_fl/ml/nn/fl/backend/torch/fl_base.py
+++ b/secretflow_fl/ml/nn/fl/backend/torch/fl_base.py
@@ -420,3 +420,9 @@ class BaseTorchModel(ABC):
         if self.use_gpu:
             self.model.to(self.exe_device)
         return checkpoint["epoch"]
+
+    def apply(self, func, *args, **kwargs):
+        if callable(func):
+            return func(self, *args, **kwargs)
+        else:
+            raise Exception("applyed method must be callable")

--- a/secretflow_fl/ml/nn/fl/backend/torch/strategy/__init__.py
+++ b/secretflow_fl/ml/nn/fl/backend/torch/strategy/__init__.py
@@ -21,6 +21,7 @@ from .fed_scr import PYUFedSCR
 from .fed_stc import PYUFedSTC
 from .moon import PYUFedMOON
 from .scaffold import PYUScaffold
+from examples.security.h_gia.FedSMP_defense.FedSMP_torch import PYUFedSMP
 
 __all__ = [
     'PYUFedAvgW',
@@ -32,4 +33,5 @@ __all__ = [
     'PYUScaffold',
     'PYUFedGen',
     'PYUFedMOON',
+    'PYUFedSMP'
 ]

--- a/tests/ml/nn/fl/strategy/test_fedsmp_torch.py
+++ b/tests/ml/nn/fl/strategy/test_fedsmp_torch.py
@@ -1,0 +1,144 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch.optim as optim
+from torch import nn
+from torch.nn import functional as F
+from torchmetrics import Accuracy, Precision
+
+import secretflow as sf
+from examples.security.h_gia.FedSMP_defense.FedSMP_torch import FedSMPServerCallback
+from secretflow import reveal
+from secretflow.security import SecureAggregator
+from secretflow_fl.ml.nn import FLModel
+from secretflow_fl.ml.nn.core.torch import (
+    BaseModule,
+    TorchModel,
+    metric_wrapper,
+    optim_wrapper,
+)
+from secretflow_fl.utils.simulation.datasets_fl import load_mnist
+
+
+# the global model
+class FLBaseNet(BaseModule):
+    def __init__(self, classes=10):
+        super(FLBaseNet, self).__init__()
+        self.act = nn.ReLU()
+        self.body = nn.Sequential(
+            nn.Conv2d(1, 32, kernel_size=3, padding=1),
+            self.act,
+            nn.AvgPool2d(kernel_size=2, stride=2),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            self.act,
+            nn.AvgPool2d(kernel_size=2, stride=2),
+        )
+        self.fc1 = nn.Linear(3136, 100)
+        self.fc2 = nn.Linear(100, classes)
+
+    def forward(self, x):
+        x = self.body(x)
+        x = x.view(x.shape[0], -1)
+        x = self.act(self.fc1(x))
+        return self.fc2(x)
+
+
+def do_test_fedsmp(configs: dict, alice, bob, carol):
+
+    # prepare dataset
+    (_, _), (data, label) = load_mnist(
+        parts={
+            alice: 0.4,
+            bob: 0.6,
+        },
+        normalized_x=True,
+        categorical_y=True,
+        is_torch=True,
+    )
+
+    loss_fn = nn.CrossEntropyLoss
+
+    optim_fn = optim_wrapper(optim.Adam, lr=configs['train_lr'])
+
+    model_def = TorchModel(
+        model_fn=FLBaseNet,
+        loss_fn=loss_fn,
+        optim_fn=optim_fn,
+        metrics=[
+            metric_wrapper(
+                Accuracy, task="multiclass", num_classes=10, average='micro'
+            ),
+            metric_wrapper(
+                Precision, task="multiclass", num_classes=10, average='micro'
+            ),
+        ],
+    )
+
+    device_list = [alice, bob]
+    server = carol
+    aggregator = SecureAggregator(server, device_list)
+
+    # spcify params
+    fl_model = FLModel(
+        server=server,
+        device_list=device_list,
+        model=model_def,
+        aggregator=aggregator,
+        strategy='fed_smp',
+        backend="torch",
+        noise_multiplier=configs['noise_multiplier'],
+        l2_norm_clip=configs['l2_norm_clip'],
+        num_clients=len(device_list),
+    )
+
+    # realize the operations in the server side with callback
+    fedsmp_server_callback = FedSMPServerCallback(
+        server=carol,
+        compression_ratio=configs['compression_ratio'],
+        global_net=FLBaseNet(),
+    )
+
+    history = fl_model.fit(
+        data,
+        label,
+        epochs=10,
+        batch_size=32,
+        aggregate_freq=1,
+        callbacks=[fedsmp_server_callback],
+    )
+
+    return
+
+
+# configurations
+configs = {
+    "batchsize": 32,
+    "epochs": 10,
+    "train_lr": 0.004,
+    "noise_multiplier": 0.04,
+    "l2_norm_clip": 1.0,
+    "compression_ratio": 0.6,
+}
+
+
+def test_fedsmp(sf_simulation_setup_devices):
+    alice = sf_simulation_setup_devices.alice
+    bob = sf_simulation_setup_devices.bob
+    carol = sf_simulation_setup_devices.carol
+    do_test_fedsmp(configs, alice, bob, carol)
+
+
+# sf.init(['alice', 'bob', 'carol'], address='local', debug_mode=True)
+# alice, bob, carol = sf.PYU('alice'), sf.PYU('bob'), sf.PYU('carol')
+# do_test_fedsmp(configs, alice, bob, carol)


### PR DESCRIPTION
## 主要改动
1. `FedSMP_torch.py`包含了FedSMP中服务器和客户端的方法
 - 定义了新的客户端strategy`FedSMP(BaseTorchModel)`客户端strategy
 - 定义了新的callback`FedSMPServerCallback(Callback)`
2. 添加了测试文件`test_fedsmp_torch.py`
3. 添加了FedSMP算法原理的说明
4. 在`secretflow_fl/ml/nn/fl/backend/torch/fl_base.py`中添加了`apply`方法

@zhaocaibei123 
