### PR TITLE
add question template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,15 +1,15 @@
 name: SecretFlow Feature Request Template
-description: To request a new feature
+description: Submit a request for a new feature
 title: "[Feature]: "
 body:
   - type: dropdown
-    id: issue-type
+    id: feature-type
     attributes:
       label: Feature Request Type
-      description: What kind of feature would you like to request?
+      description: What category does your feature request fall under?
       multiple: false
       options:
-        - Build/Install
+        - Build/Installation
         - Performance
         - Support
         - Usability
@@ -18,32 +18,53 @@ body:
         - Others
     validations:
       required: true
+
+  - type: dropdown
+    id: resolution-preference
+    attributes:
+      label: Resolution Preference
+      description: Would you like to work on this feature yourself, or would you prefer the SecretFlow Team or Community to handle it?
+      multiple: false
+      options:
+        - I would like to contribute!
+        - I hope the SecretFlow Team or Community can assist!
+    validations:
+      required: true
+
   - type: dropdown
     id: search-check
     attributes:
-      label: Have you searched existing issues?
-      description: To prevent duplicated reports, it is strongly suggested that you search existing issues first.
-      options: ['Yes', 'No']
+      label: Existing Issue Search
+      description: Have you checked for existing issues to avoid duplication?
+      options:
+        - Yes
+        - No
     validations:
       required: true
+
   - type: textarea
     id: justification
     attributes:
-      label: Justification for the Feature
-      value: Please provide a reason why you want to add this feature.
+      label: Feature Justification
+      description: Please explain why this feature is important or necessary.
+      value: 
     validations:
       required: true
+
   - type: textarea
     id: proposed-feature
     attributes:
-      label: Proposed Feature Description
-      value: A clear and concise description of what you want to happen.
+      label: Feature Description
+      description: Provide a clear and concise description of the desired feature.
+      value: 
     validations:
       required: true
+
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternative Solutions Considered
-      value: A clear and concise description of any alternative solutions or features you've considered.
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      value: 
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/usage_questions.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_questions.yaml
@@ -1,20 +1,16 @@
-name: Secretflow Bug Report Template
-description: Thank you for taking the time to report a bug!
+name: Secretflow Usage Question Template
+description: Welcome to the Secretflow community! Feel free to ask any questions you have.
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping us improve Secretflow by reporting a bug!
-        
-        Please ensure that your report pertains to an issue in the code, documentation, or during the build/installation process. Note that usage-related queries do not constitute bugs. Errors resulting from incorrect input are not considered bugs.
-
-        If you are unsure whether your issue is a bug or have general questions, please use the usage question template. We also encourage you to engage with our community in the [discussions](https://github.com/secretflow/secretflow/discussions) section to ask questions or share ideas.
+        Welcome to the Secretflow community! We're here to help with any questions you have about using Secretflow. If you're unsure whether your query is a bug or a request, don't hesitate to ask here!
 
   - type: dropdown
     id: issue-type
     attributes:
-      label: Issue Type
-      description: What type of bug are you reporting?
+      label: Question Category
+      description: What type of question do you have?
       multiple: false
       options:
         - Build/Installation
@@ -25,12 +21,12 @@ body:
         - Others
     validations:
       required: true
-
+    
   - type: dropdown
     id: source
     attributes:
       label: Installation Source
-      description: How was Secretflow installed?
+      description: How did you install Secretflow?
       options:
         - Binary
         - Source
@@ -41,7 +37,7 @@ body:
     id: sfversion
     attributes:
       label: Secretflow Version
-      description: Specify the version of Secretflow you are using.
+      description: Please specify the version of Secretflow you are using.
       placeholder: e.g., secretflow 0.6.13b0
     validations:
       required: true
@@ -50,7 +46,7 @@ body:
     id: OS
     attributes:
       label: Operating System and Distribution
-      description: Specify your operating system and distribution.
+      description: Please specify your operating system and distribution.
       placeholder: e.g., Linux Ubuntu 18.04
     validations:
       required: true
@@ -59,7 +55,7 @@ body:
     id: Python
     attributes:
       label: Python Version
-      description: Specify the version of Python you are using.
+      description: Please specify the version of Python you are using.
       placeholder: e.g., 3.10.13
     validations:
       required: true
@@ -68,7 +64,7 @@ body:
     id: Bazel
     attributes:
       label: Bazel Version
-      description: Specify the Bazel version if compiling from source.
+      description: Please specify the Bazel version if compiling from source.
       placeholder: e.g., 4.2.1
     validations:
       required: false
@@ -77,7 +73,7 @@ body:
     id: Compiler
     attributes:
       label: GCC/Compiler Version
-      description: Specify the GCC/Compiler version if compiling from source.
+      description: Please specify the GCC/Compiler version if compiling from source.
       placeholder: e.g., GCC 9.3.0
     validations:
       required: false
@@ -85,9 +81,9 @@ body:
   - type: textarea
     id: what-happened
     attributes:
-      label: Issue Description
-      description: Describe the issue, including expected and actual outcomes. Attach relevant logs.
-      placeholder: Explain how the expected outcome differs from the actual result.
+      label: Question Details
+      description: Describe your objective, the issue you are facing, and your expected outcome.
+      placeholder: I'm trying to achieve this, but I'm encountering this issue.
       value: 
       render: shell
     validations:
@@ -97,18 +93,18 @@ body:
     id: reproduction-code
     attributes:
       label: Reproduction Code
-      description: Provide the minimal code necessary to reproduce the issue. Include any relevant data.
-      placeholder: Include a short code snippet to reproduce the issue.
+      description: If applicable, provide minimal code necessary to illustrate the issue. Include any relevant data.
+      placeholder: Include a short code snippet if it helps explain your question.
       value: 
       render: shell
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: additional-context
     attributes:
       label: Additional Context or Logs
-      description: Provide any additional information that may help debug the issue, such as logs or screenshots.
+      description: Include any additional information that may help clarify your question, such as logs or screenshots.
       placeholder: Attach logs, screenshots, or any additional relevant information here.
       value: 
       render: shell


### PR DESCRIPTION
Add an issue template for general question.

We recommend users to use the usage-question template by default.

Unless you are certain about the issue is a bug or feature request, use the usage-question template please.

