### PR TITLE
在快速开始中删除lite版本内容

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,7 +1,5 @@
 # Installation
 
-Secretflow is available in two editions: Lite and Full. The Lite edition is optimized for minimal size by excluding deep-learning related dependencies, making it more compact. On the other hand, the Full edition encompasses the complete set of dependencies for users requiring the full functionality of deep learning integration. Select the edition that best aligns with your specific requirements.
-
 The simplest way to try SecretFlow is to use [offical docker image](#option-2-from-docker) which ships with SecretFlow binary.
 
 Or you could [install SecretFlow via Python Package Index](#option-1-from-pypi).
@@ -38,27 +36,15 @@ conda activate sf
 
 After that, please use pip to install SecretFlow.
 
-- Full edition
 ```bash
 pip install -U secretflow
-```
-
-- Lite edition
-```bash
-pip install -U secretflow-lite
 ```
 
 ## Option 2: from docker
 You can also use SecretFlow Docker image to give SecretFlow a quick try.
 
-- Full edition
 ```bash
 docker run -it secretflow/secretflow-anolis8:latest
-```
-
-- Lite edition
-```bash
-docker run -it secretflow/secretflow-lite-anolis8:latest
 ```
 
 More versions can be obtained from [secretflow tags](https://hub.docker.com/r/secretflow/secretflow-anolis8/tags).
@@ -77,18 +63,9 @@ conda activate secretflow
 
 2. Install SecretFlow
 
-- Full edition
 ```sh
 
 python setup.py bdist_wheel
-
-pip install dist/*.whl
-```
-
-- Lite edition
-```sh
-
-python setup.py bdist_wheel --lite
 
 pip install dist/*.whl
 ```
@@ -121,15 +98,10 @@ conda activate sf
 ```
 
 - use pip to install SecretFlow.
-    
-    - Full edition
-    ```
-    pip install -U secretflow
-    ```
-    - Lite edition
-    ```
-    pip install -U secretflow-lite
-    ```
+
+```
+pip install -U secretflow
+```
 
 4. Use WSL to develop your application
 


### PR DESCRIPTION
**Type of change**


- [ ] Add new papers (Please tell us why you think this paper is awesome!)
- [x] Fix the category of an existing paper/papers (Please tell us the reasons)
- [ ] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**
> 删除installation.md(quickstart/Installation)文档中关于lite版本的描述，原因是安装lite版本不支持SIMULATION模式，会导致运行quick-try失败
```
NotSupportedError: 
*************************
code        : 31001008
reason      : DISTRIBUTION_MODE.SIMULATION mode is not supported in lite version, please try it in full version.
description : NOT_SUPPORTED_ERROR
explanation : 
*************************
```