### PR TITLE
fix: fix the `MinMaxScaler` and `LabelEncoder` import path

### DIFF
--- a/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
+++ b/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -40,7 +40,10 @@
    "source": [
     "import secretflow as sf\n",
     "\n",
-    "sf.shutdown()\n",
+    "try:\n",
+    "    sf.shutdown()\n",
+    "except:\n",
+    "    print(\"Clean up the environment\")\n",
     "sf.init(['alice', 'bob'], address='local')\n",
     "alice, bob = sf.PYU('alice'), sf.PYU('bob')"
    ]
@@ -57,13 +60,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from secretflow.utils.simulation.datasets import load_bank_marketing\n",
-    "from secretflow.preprocessing.scaler import MinMaxScaler\n",
-    "from secretflow.preprocessing.encoder import LabelEncoder\n",
+    "from secretflow_fl.preprocessing.scaler_fl import MinMaxScaler\n",
+    "from secretflow_fl.preprocessing.encoder_fl import LabelEncoder\n",
     "from secretflow.data.split import train_test_split\n",
     "\n",
     "random_state = 1234\n",


### PR DESCRIPTION
Resolves #1731 

1. correct the import path of `MinMaxScaler` and `LabelEncoder` from `secretflow_fl.preprocessing.scaler_fl` and `secretflow_fl.preprocessing.encoder_fl`
2. add "try expect" block to catch the potential `TypeError` occurence when implement `sf.shutdown()`, refering to the screenshot below


![IMG_6384](https://github.com/user-attachments/assets/17ac5389-9fb4-457f-add2-bb64bb0172ea)

