### PR TITLE
fix: fix the `MinMaxScaler` and `LabelEncoder` import path

### DIFF
--- a/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
+++ b/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -40,7 +40,10 @@
    "source": [
     "import secretflow as sf\n",
     "\n",
-    "sf.shutdown()\n",
+    "try: \n",
+    "    sf.shutdown() \n",
+    "except TypeError: \n",
+    "    print(\"Clean up the environment\")\n",
     "sf.init(['alice', 'bob'], address='local')\n",
     "alice, bob = sf.PYU('alice'), sf.PYU('bob')"
    ]
@@ -57,13 +60,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from secretflow.utils.simulation.datasets import load_bank_marketing\n",
-    "from secretflow.preprocessing.scaler import MinMaxScaler\n",
-    "from secretflow.preprocessing.encoder import LabelEncoder\n",
+    "from secretflow_fl.preprocessing.scaler_fl import MinMaxScaler\n",
+    "from secretflow_fl.preprocessing.encoder_fl import LabelEncoder\n",
     "from secretflow.data.split import train_test_split\n",
     "\n",
     "random_state = 1234\n",

--- a/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
+++ b/docs/user_guide/federated_learning/vertical_federated_learning/SplitRec/efficiency/sl_pipeline.ipynb
@@ -40,9 +40,9 @@
    "source": [
     "import secretflow as sf\n",
     "\n",
-    "try: \n",
-    "    sf.shutdown() \n",
-    "except TypeError: \n",
+    "try:\n",
+    "    sf.shutdown()\n",
+    "except TypeError:\n",
     "    print(\"Clean up the environment\")\n",
     "sf.init(['alice', 'bob'], address='local')\n",
     "alice, bob = sf.PYU('alice'), sf.PYU('bob')"


### PR DESCRIPTION
**Type of change**

- [ ] Add new papers (Please tell us why you think this paper is awesome!)
- [x] Fix the category of an existing paper/papers (Please tell us the reasons)
- [ ] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**

Resolves https://github.com/secretflow/secretflow/issues/1731

1. correct the import path of `MinMaxScaler` and `LabelEncoder` from `secretflow_fl.preprocessing.scaler_fl` and `secretflow_fl.preprocessing.encoder_fl`
2. add "try expect" block to catch the potential `TypeError` occurence when implement `sf.shutdown()`, referring to the screenshot below
![image](https://github.com/user-attachments/assets/dfbf981d-b6ea-4916-a518-f5ef7bd49a92)
