### PR TITLE
Add split learning sim_lia method (IEEE2024)

### DIFF
--- a/benchmark_examples/autoattack/applications/image/cifar10/cifar10_base.py
+++ b/benchmark_examples/autoattack/applications/image/cifar10/cifar10_base.py
@@ -51,12 +51,12 @@ class Cifar10ApplicationBase(ApplicationBase, ABC):
         return 'cifar10'
 
     def prepare_data(self):
-        from secretflow.utils.simulation import datasets
+        from secretflow_fl.utils.simulation import datasets_fl
 
         (train_data, train_label), (
             test_data,
             test_label,
-        ) = datasets.load_cifar10(
+        ) = datasets_fl.load_cifar10(
             [self.alice, self.bob],
         )
 

--- a/benchmark_examples/autoattack/attacks/__init__.py
+++ b/benchmark_examples/autoattack/attacks/__init__.py
@@ -35,5 +35,5 @@ __all__ = [
     'fsha',
     'batch_lia',
     'sdar',
-    'sim_lia'
+    'sim_lia',
 ]

--- a/benchmark_examples/autoattack/attacks/__init__.py
+++ b/benchmark_examples/autoattack/attacks/__init__.py
@@ -22,6 +22,7 @@ from .norm import NormAttackCase as norm
 from .replace import ReplaceAttackCase as replace
 from .replay import ReplayAttackCase as replay
 from .sdar import SdarAttackCase as sdar
+from .sim_lia import SimilarityLiaAttackCase as sim_lia
 
 __all__ = [
     'exploit',
@@ -34,4 +35,5 @@ __all__ = [
     'fsha',
     'batch_lia',
     'sdar',
+    'sim_lia'
 ]

--- a/benchmark_examples/autoattack/attacks/sim_lia.py
+++ b/benchmark_examples/autoattack/attacks/sim_lia.py
@@ -1,0 +1,82 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file references code of paper : Similarity-based Label Inference Attack against Training and Inference of Split Learning(IEEE2024)
+
+https://ieeexplore.ieee.org/document/10411061
+"""
+
+from typing import Dict
+
+from benchmark_examples.autoattack.applications.base import ApplicationBase, InputMode
+from benchmark_examples.autoattack.attacks.base import AttackBase, AttackType
+from benchmark_examples.autoattack.utils.resources import ResourcesPack
+from secretflow_fl.ml.nn.callbacks.attack import AttackCallback
+from secretflow_fl.ml.nn.sl.attacks.sim_lia_torch import SimilarityLabelInferenceAttack
+
+
+class SimilarityLiaAttackCase(AttackBase):
+    """
+    Similartity-based LIA method.
+    """
+
+    def __init__(self, alice=None, bob=None):
+        super().__init__(alice, bob)
+
+    def __str__(self):
+        return 'sim_lia'
+
+    def build_attack_callback(self, app: ApplicationBase) -> AttackCallback:
+        # although the original paper use different known_data but
+        availabel_data_type = ["feature", "grad"]
+        availabel_attack_method = ["k-means", "distance"]
+        availabel_distance_metric = ["euclidean", "cosine"]
+        all_availabel_options = {
+            "k-means": ["feature", "grad"],
+            "distance": {
+                "cosine": ["feature", "grad"],
+                "euclidean": ["feature", "grad"],
+            },
+        }
+
+        return SimilarityLabelInferenceAttack(
+            attack_party=app.device_f,
+            label_party=app.device_y,
+            data_type=self.config.get("data_type", "grad"),
+            attack_method=self.config.get("attack_method", "distance"),
+            known_num=1,
+            distance_metric="cosine",
+            exec_device="cpu",
+        )
+
+    def attack_type(self) -> AttackType:
+        return AttackType.LABLE_INFERENSE
+
+    def tune_metrics(self) -> Dict[str, str]:
+        return {'attack_acc': 'max'}
+
+    def check_app_valid(self, app: ApplicationBase) -> bool:
+        return app.base_input_mode() in [InputMode.SINGLE]
+
+    def update_resources_consumptions(
+        self, cluster_resources_pack: ResourcesPack, app: ApplicationBase
+    ) -> ResourcesPack:
+        update_gpu = lambda x: x * 1.3
+        update_memory = lambda x: x * 1.02
+        return (
+            cluster_resources_pack.apply_debug_resources('gpu_mem', update_gpu)
+            .apply_debug_resources('memory', update_memory)
+            .apply_sim_resources(app.device_f.party, 'gpu_mem', update_gpu)
+            .apply_sim_resources(app.device_f.party, 'memory', update_memory)
+        )

--- a/benchmark_examples/autoattack/main.py
+++ b/benchmark_examples/autoattack/main.py
@@ -47,7 +47,7 @@ import benchmark_examples.autoattack.utils.dispatch as dispatch
 import secretflow as sf
 import secretflow.distributed as sfd
 from benchmark_examples.autoattack import global_config
-from secretflow import tune
+from secretflow_fl import tune
 from secretflow.distributed.const import DISTRIBUTION_MODE
 from secretflow.utils.errors import NotSupportedError
 

--- a/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
+++ b/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
@@ -1,0 +1,250 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file references code of paper Label Inference Attacks Against Federated Learning on Usenix Security 2022: https://www.usenix.org/conference/usenixsecurity22/presentation/fu-chong
+"""
+
+
+import numpy as np
+
+from secretflow.device import PYU, reveal, wait
+from secretflow_fl.ml.nn.callbacks.attack import AttackCallback
+
+from sklearn.cluster import KMeans
+from scipy.optimize import linear_sum_assignment
+import sklearn.preprocessing as preprocessing
+
+
+def cosine_distance(x: np.array, y: np.array):
+    # cosine distance. Use -1 to convert cosine similarity to distance
+    return -np.dot(x, y) / (np.linalg.norm(x) * np.linalg.norm(y))
+
+
+def euclidean_distance(x: np.array, y: np.array):
+    # euclidean distance
+    return np.linalg.norm(x - y)
+
+
+def distance_based(measure="cosine"):
+    def distance_attack(
+        collect_data: np.array, known_data: np.array, known_label: dict
+    ):
+        if measure == "cosine":
+            similarity = cosine_distance
+        else:
+            similarity = euclidean_distance
+        collect_label = []
+        for i in range(collect_data.shape[0]):
+            sim = [
+                similarity(collect_data[i], known_data[j])
+                for j in range(known_data.shape[0])
+            ]
+            collect_label.append(known_label[np.argmin(sim)])
+        return np.array(collect_label)
+
+    return distance_attack
+
+
+def kmeans_based(collect_data: np.array, known_data: np.array, known_labels: dict):
+
+    unique_labels = np.unique(known_labels)
+    n_clusters = len(unique_labels)
+
+    known_dict = {}
+    for label in unique_labels:
+        known_dict[label] = known_data[known_labels == label]
+
+    init_centroids = []
+    for label in unique_labels:
+        centroid = known_dict[label][np.random.choice(len(known_dict[label]))]
+        init_centroids.append(centroid)
+
+    kmeans = KMeans(n_clusters=n_clusters, init=np.array(init_centroids), n_init=1)
+    kmeans.fit(collect_data)
+
+    cluster_labels = kmeans.labels_
+    known_cluster_labels = kmeans.predict(known_data)
+    confusion_matrix = np.zeros((n_clusters, n_clusters), dtype=np.int64)
+    for i in range(len(known_labels)):
+        true_label_idx = np.where(unique_labels == known_labels[i])[0][0]
+        pred_label_idx = known_cluster_labels[i]
+        confusion_matrix[true_label_idx, pred_label_idx] += 1
+    row_ind, col_ind = linear_sum_assignment(confusion_matrix.max() - confusion_matrix)
+    cluster_to_label_map = {
+        col_ind[i]: unique_labels[row_ind[i]] for i in range(len(row_ind))
+    }
+    pred_labels = np.array(
+        [cluster_to_label_map.get(label, -1) for label in cluster_labels]
+    )
+    return pred_labels
+
+
+def random_known_data(known_data, known_label, num=2):
+    known_data_list = []
+    known_label_list = []
+    for i in np.unique(known_label):
+        idx = np.where(known_label == i)[0]
+        idx = np.random.choice(idx, num, replace=False)
+        known_data_list.append(known_data[idx])
+        known_label_list.append(known_label[idx])
+    known_data = np.concatenate(known_data_list, axis=0)
+    known_label = np.concatenate(known_label_list, axis=0)
+    return known_data, known_label
+
+
+def get_attack_method(attack_method, measure="cosine"):
+    if attack_method == "distance":
+        return distance_based(measure=measure)
+    elif attack_method == "k-means":
+        return kmeans_based
+    else:
+        raise ValueError(f"Unknown attack method: {attack_method}")
+
+
+class SimilarityLabelInferenceAttack(AttackCallback):
+    """
+    Implementation of sim_lia aglorithm in paper: Similarity-based Label Inference Attack against Training and Inference of Split Learning
+    Attributes:
+        attack_party: The party that performs the attack.
+        label_party: The party that has the labels.
+        data_type: The type of data to be used for the attack. Can be "feature" or "grad".
+        attack_method: The method used for the attack. Can be "distance" or "k-means".
+        known_num: The number of known data points to be used for the attack.
+        distance_metric: The distance metric to be used for the attack. Can be "cosine" or "euclidean".
+        exec_device: The device to be used for execution. Can be "cpu" or "gpu".
+        params: Additional parameters for the attack.
+    """
+
+    def __init__(
+        self,
+        attack_party: PYU,
+        label_party: PYU,
+        data_type: str,
+        attack_method: str,
+        known_num: int,
+        distance_metric="cosine",
+        exec_device="cpu",
+        **params,
+    ):
+        super().__init__(
+            **params,
+        )
+
+        self.attack_party = attack_party
+        self.label_party = label_party
+
+        self.data_type = data_type
+        self.attack_method = attack_method
+        self.distance_metric = distance_metric
+        self.known_num = known_num
+        self.exec_device = exec_device
+
+        if self.attack_method not in ["distance", "k-means"]:
+            raise ValueError(
+                f"attack_method should be distance or k-means, but got {self.attack_method}"
+            )
+
+        if self.attack_method == "distance":
+            self.known_num = 1
+
+        self.attack_func = get_attack_method(self.attack_method, self.distance_metric)
+
+        self.last_epoch = False
+
+        self.res = None
+        self.metrics = None
+
+    def on_epoch_begin(self, epoch=None, logs=None):
+        # The attacker uses the method during the final epoch.
+        if epoch == self.params["epochs"] - 1:
+            self.last_epoch = True
+
+        def prepare_store(worker):
+            if self.last_epoch:
+                worker._callback_store["data"] = []
+
+        self._workers[self.attack_party].apply(prepare_store)
+
+    def on_base_forward_end(self):
+        # record hidden state value
+        if self.data_type == "feature":
+
+            def record_data(worker):
+                if (
+                    worker.model_base.training
+                    and worker._callback_store.get("data", None) is not None
+                ):
+                    if isinstance(worker._h, list):
+                        data = worker._h[0].cpu().detach().numpy()
+                    else:
+                        data = worker._h.cpu().detach().numpy()
+                    worker._callback_store["data"].append(data)
+
+            self._workers[self.attack_party].apply(record_data)
+
+    def on_base_backward_end(self):
+        # record grad value
+        if self.data_type == "grad":
+
+            def record_data(worker):
+                if (
+                    worker.model_base.training
+                    and worker._callback_store.get("data", None) is not None
+                ):
+                    grad = worker._gradient.cpu().numpy()
+                    worker._callback_store["data"].append(grad)
+
+            self._workers[self.attack_party].apply(record_data)
+
+    def on_fuse_forward_begin(self):
+        if self.last_epoch:
+
+            def get_label(worker):
+                if isinstance(worker.train_y, list):
+                    label = worker.train_y[0].cpu().detach().numpy()
+                else:
+                    label = worker.train_y.cpu().detach().numpy()
+                return label
+
+            label = self._workers[self.label_party].apply(get_label)
+
+            def store_label(worker, label):
+                if worker._callback_store.get("labels", None) is None:
+                    worker._callback_store["labels"] = []
+                worker._callback_store["labels"].append(label)
+
+            # reveal the data due to the evaluate
+            label = reveal(label)
+            self._workers[self.attack_party].apply(store_label, label)
+
+    def on_train_end(self, logs=None):
+
+        def label_inference_attack(worker):
+            data = np.concatenate(worker._callback_store["data"], axis=0)
+            labels = np.concatenate(worker._callback_store["labels"], axis=0)
+            data = preprocessing.normalize(data)
+            data = data.reshape((data.shape[0], -1))
+
+            known_data, known_label = random_known_data(data, labels, self.known_num)
+            result_label = self.attack_func(data, known_data, known_label)
+            res = {"attack_acc": sum(result_label == labels) / len(labels)}
+            return res
+
+        res = self._workers[self.attack_party].apply(label_inference_attack)
+        wait(res)
+        self.metrics = reveal(res)
+
+    def get_attack_metrics(self):
+        return self.metrics

--- a/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
+++ b/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 """
-This file references code of paper Label Inference Attacks Against Federated Learning on Usenix Security 2022: https://www.usenix.org/conference/usenixsecurity22/presentation/fu-chong
+This file references code of paper : Similarity-based Label Inference Attack against Training and Inference of Split Learning(IEEE2024)
+https://ieeexplore.ieee.org/document/10411061
 """
-
 
 import numpy as np
 

--- a/tests/ml/nn/sl/attack/test_torch_sim_lia.py
+++ b/tests/ml/nn/sl/attack/test_torch_sim_lia.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 import numpy as np
 
 
@@ -27,7 +26,6 @@ from secretflow_fl.ml.nn.core.torch import TorchModel, metric_wrapper, optim_wra
 from secretflow_fl.ml.nn.sl.attacks.sim_lia_torch import SimilarityLabelInferenceAttack
 
 
-
 def do_test_sl_and_sim_lia(alice, bob, config):
 
     class BaseNet(nn.Module):
@@ -39,17 +37,17 @@ def do_test_sl_and_sim_lia(alice, bob, config):
             self.ReLU = nn.ReLU()
 
         def forward(self, x):
-            
+
             x = self.fc1(x)
             x = self.ReLU(x)
             x = self.fc2(x)
             x = self.ReLU(x)
             x = self.fc3(x)
             return x
-        
+
         def output_num(self):
             return 1
-        
+
     class FuseNet(nn.Module):
         def __init__(self):
             super(FuseNet, self).__init__()
@@ -62,10 +60,10 @@ def do_test_sl_and_sim_lia(alice, bob, config):
             x = self.ReLU(x)
             x = self.fc2(x)
             return x
-    
+
     train_data = np.random.rand(1000, 100).astype(np.float32)
     train_label = np.random.randint(0, 10, size=(1000,)).astype(np.int64)
-    
+
     # put into FedNdarray
     fed_data = FedNdarray(
         partitions={
@@ -118,9 +116,13 @@ def do_test_sl_and_sim_lia(alice, bob, config):
         backend="torch",
         strategy="split_nn",
     )
-    
+
     attack_method, data_type, distance_metric = config.split(",")
-    logging.info((f"attack_method: {attack_method}, distance_metric: {distance_metric}, data_type: {data_type}"))
+    logging.info(
+        (
+            f"attack_method: {attack_method}, distance_metric: {distance_metric}, data_type: {data_type}"
+        )
+    )
 
     sim_lia_callback = SimilarityLabelInferenceAttack(
         attack_party=alice,
@@ -152,7 +154,13 @@ def do_test_sl_and_sim_lia(alice, bob, config):
 def test_sl_and_lia(sf_simulation_setup_devices):
     alice = sf_simulation_setup_devices.alice
     bob = sf_simulation_setup_devices.bob
-    config = ["k-means,feature,cosine", "k-means,grad,cosine", "distance,feature,cosine","distance,grad,cosine","distance,feature,euclidean","distance,grad,euclidean"]
+    config = [
+        "k-means,feature,cosine",
+        "k-means,grad,cosine",
+        "distance,feature,cosine",
+        "distance,grad,cosine",
+        "distance,feature,euclidean",
+        "distance,grad,euclidean",
+    ]
     for i in config:
         do_test_sl_and_sim_lia(alice, bob, i)
-

--- a/tests/ml/nn/sl/attack/test_torch_sim_lia.py
+++ b/tests/ml/nn/sl/attack/test_torch_sim_lia.py
@@ -1,0 +1,158 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+import numpy as np
+
+
+import torch.nn as nn
+import torch.optim as optim
+from torchmetrics import Accuracy
+import logging
+from secretflow.data.ndarray import FedNdarray, PartitionWay
+from secretflow_fl.ml.nn import SLModel
+from secretflow_fl.ml.nn.core.torch import TorchModel, metric_wrapper, optim_wrapper
+from secretflow_fl.ml.nn.sl.attacks.sim_lia_torch import SimilarityLabelInferenceAttack
+
+
+
+def do_test_sl_and_sim_lia(alice, bob, config):
+
+    class BaseNet(nn.Module):
+        def __init__(self):
+            super(BaseNet, self).__init__()
+            self.fc1 = nn.Linear(100, 100)
+            self.fc2 = nn.Linear(100, 100)
+            self.fc3 = nn.Linear(100, 100)
+            self.ReLU = nn.ReLU()
+
+        def forward(self, x):
+            
+            x = self.fc1(x)
+            x = self.ReLU(x)
+            x = self.fc2(x)
+            x = self.ReLU(x)
+            x = self.fc3(x)
+            return x
+        
+        def output_num(self):
+            return 1
+        
+    class FuseNet(nn.Module):
+        def __init__(self):
+            super(FuseNet, self).__init__()
+            self.fc1 = nn.Linear(100, 100)
+            self.fc2 = nn.Linear(100, 10)
+            self.ReLU = nn.ReLU()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.ReLU(x)
+            x = self.fc2(x)
+            return x
+    
+    train_data = np.random.rand(1000, 100).astype(np.float32)
+    train_label = np.random.randint(0, 10, size=(1000,)).astype(np.int64)
+    
+    # put into FedNdarray
+    fed_data = FedNdarray(
+        partitions={
+            alice: alice(lambda x: x)(train_data),
+            # bob: bob(lambda x: x)(train_data),
+        },
+        partition_way=PartitionWay.VERTICAL,
+    )
+
+    label = bob(lambda x: x)(train_label)
+
+    # model configure
+    loss_fn = nn.CrossEntropyLoss
+
+    optim_fn = optim_wrapper(optim.SGD, lr=1e-2, momentum=0.9, weight_decay=5e-4)
+
+    _base_model, _fuse_model = BaseNet, FuseNet
+
+    base_model = TorchModel(
+        model_fn=_base_model,
+        loss_fn=loss_fn,
+        optim_fn=optim_fn,
+        metrics=[
+            metric_wrapper(
+                Accuracy, task="multiclass", num_classes=10, average="micro"
+            ),
+        ],
+    )
+
+    fuse_model = TorchModel(
+        model_fn=_fuse_model,
+        loss_fn=loss_fn,
+        optim_fn=optim_fn,
+        metrics=[
+            metric_wrapper(
+                Accuracy, task="multiclass", num_classes=10, average="micro"
+            ),
+        ],
+    )
+
+    base_model_dict = {
+        alice: base_model,
+    }
+
+    sl_model = SLModel(
+        base_model_dict=base_model_dict,
+        device_y=bob,
+        model_fuse=fuse_model,
+        simulation=True,
+        backend="torch",
+        strategy="split_nn",
+    )
+    
+    attack_method, data_type, distance_metric = config.split(",")
+    logging.info((f"attack_method: {attack_method}, distance_metric: {distance_metric}, data_type: {data_type}"))
+
+    sim_lia_callback = SimilarityLabelInferenceAttack(
+        attack_party=alice,
+        label_party=bob,
+        data_type=data_type,
+        attack_method=attack_method,
+        known_num=10,
+        distance_metric=distance_metric,
+        exec_device="cpu",
+    )
+
+    history = sl_model.fit(
+        fed_data,
+        label,
+        validation_data=(fed_data, label),
+        epochs=2,
+        batch_size=128,
+        random_seed=1234,
+        callbacks=[sim_lia_callback],
+    )
+    print(history)
+
+    pred_bs = 128
+    result = sl_model.predict(fed_data, batch_size=pred_bs, verbose=1)
+
+    return sim_lia_callback.get_attack_metrics()
+
+
+def test_sl_and_lia(sf_simulation_setup_devices):
+    alice = sf_simulation_setup_devices.alice
+    bob = sf_simulation_setup_devices.bob
+    config = ["k-means,feature,cosine", "k-means,grad,cosine", "distance,feature,cosine","distance,grad,cosine","distance,feature,euclidean","distance,grad,euclidean"]
+    for i in config:
+        do_test_sl_and_sim_lia(alice, bob, i)
+


### PR DESCRIPTION
**Type of change**

- [x] Add new papers (Please tell us why you think this paper is awesome!)
- [ ] Fix the category of an existing paper/papers (Please tell us the reasons)
- [ ] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**
Here's the English translation of the PR content:

Added the sim_lia algorithm, based on the 2024 IEEE paper "Similarity-based Label Inference Attack against Training and Inference of Split Learning." https://ieeexplore.ieee.org/document/10411061
![image](https://github.com/user-attachments/assets/fb5cd3f7-6028-4dff-ad04-37e0135e58a7)

The method is based on cosine distance and Euclidean distance of smashed data and gradients. The attack can be distance-based or clustering-based, with the following options:

```python
availabel_data_type = ["feature", "grad"]
availabel_attack_method = ["k-means", "distance"]
availabel_distance_metric = ["euclidean", "cosine"]
all_availabel_options = {
    "k-means": ["feature", "grad"],
    "distance": {
        "cosine": ["feature", "grad"],
        "euclidean": ["feature", "grad"],
    },
}
```


Due to its generality, it can be used in a wide range of scenarios. Currently, its attack performance on autoattack is as follows:

| App              | Epoch | Acc     | Attack Acc |
| ---------------- | ----- | ------- | ---------- |
| ResNet20 Cifar10 | 2     | 43.336% | 29.636%    |
| ResNet18 Cifar10 | 10    | 88.077% | 99.122%    |
| CNN Cifar10      | 10    | 86.467% | 77.458%    |
| VGG16 Cifar10    | 10    | 82.748% | 50.184%    |
| ResNet18 MNIST   | 5     | 98.834% | 82.813%    |
| VGG16 MNIST      | 1     | 79.949% | 55.935%    |

In addition, fixed the incorrect import issues in benchmark_examples caused by the previous SecretFlow refactoring.

