### PR TITLE
【OSCP Docs】 验证文档「SPU基础」 #1871

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/tutorial/spu_basics.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/tutorial/spu_basics.po
@@ -428,7 +428,7 @@ msgid ""
 "*PYUObject*! And it’s owned by dave. Let’s check the value of "
 "*new_bank_account_pyu*."
 msgstr ""
-"我们只是将 *new\\_bank\\account\\spu* 传递给 **pyu** ，然后它就变成了 *PYUObject* ！ "
+"我们只是将 *new\\_bank\\_account\\_spu* 传递给 **pyu** ，然后它就变成了 *PYUObject* ！ "
 "它归dave所有。 让我们检查 *new\\_bank\\_account\\_pyu* 的值。"
 
 #: ../../tutorial/spu_basics.ipynb:1102
@@ -500,7 +500,7 @@ msgstr "这是 SPU 的默认行为。 让我们来看看。"
 
 #: ../../tutorial/spu_basics.ipynb:1507
 msgid "We could see we only get a single *SPUObject*. Let’s reveal it."
-msgstr "我们可以看到我们只得到一个*SPUObject*。 让我们揭示它。"
+msgstr "我们可以看到我们只得到一个 *SPUObject* 。 让我们揭示它。"
 
 #: ../../tutorial/spu_basics.ipynb:1553
 msgid "So single_output itself actually represents a tuple."


### PR DESCRIPTION
Fixed：#1871

修改了**错误变量名**。对应英文版本是正确的，故只修改了中文版本的SPU_basic.po
<br/>

> <img width="825" alt="image" src="https://github.com/user-attachments/assets/5d121294-6b4c-4b20-bf95-fa10f28187ad" />



<br/>修改了一处**格式错误**。对应英文版本是正确的，故只修改了中文版本的SPU_basic.po


> <img width="766" alt="image" src="https://github.com/user-attachments/assets/3535b543-4785-474c-ba3e-8d0fc45f1acc" />


除此之外，运行正确。

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/6aef0167-0c5a-412b-8d4d-ff59869e5eea" />


<img width="1172" alt="image" src="https://github.com/user-attachments/assets/bb373969-110e-4318-9892-19f7d703c63e" />

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/ee6f603a-5dd9-4edc-abcf-dca2de0a0e3d" />


<img width="1301" alt="image" src="https://github.com/user-attachments/assets/707a7ad7-7dad-4a42-90dd-57e2b7c38ade" />

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/6502cfb3-f9c3-450f-b62e-bc7024b9e7fc" />

<img width="815" alt="image" src="https://github.com/user-attachments/assets/3efdf241-0c1f-48eb-861e-df6dd84fc282" />


