### PR TITLE
Add split learning PELoss defense and some benchmark.(IJCAI2024)

### DIFF
--- a/benchmark_examples/autoattack/attacks/sim_lia.py
+++ b/benchmark_examples/autoattack/attacks/sim_lia.py
@@ -53,7 +53,7 @@ class SimilarityLiaAttackCase(AttackBase):
         return SimilarityLabelInferenceAttack(
             attack_party=app.device_f,
             label_party=app.device_y,
-            data_type=self.config.get("data_type", "grad"),
+            data_type=self.config.get("data_type", "feature"),
             attack_method=self.config.get("attack_method", "distance"),
             known_num=1,
             distance_metric="cosine",

--- a/benchmark_examples/autoattack/defenses/__init__.py
+++ b/benchmark_examples/autoattack/defenses/__init__.py
@@ -21,4 +21,13 @@ from .mixup import Mixup as mixup
 from .loss_defense import PELossDefense as peloss
 from .loss_defense import DcorLossDefense as dcorloss
 
-__all__ = ['grad_avg', 'mixup', 'de_identification', 'mid', 'fed_pass', 'cae', "peloss", "dcorloss"]
+__all__ = [
+    'grad_avg',
+    'mixup',
+    'de_identification',
+    'mid',
+    'fed_pass',
+    'cae',
+    "peloss",
+    "dcorloss",
+]

--- a/benchmark_examples/autoattack/defenses/__init__.py
+++ b/benchmark_examples/autoattack/defenses/__init__.py
@@ -18,5 +18,7 @@ from .fed_pass import FedPass as fed_pass
 from .grad_avg import GradientAverageCase as grad_avg
 from .mid import Mid as mid
 from .mixup import Mixup as mixup
+from .loss_defense import PELossDefense as peloss
+from .loss_defense import DcorLossDefense as dcorloss
 
-__all__ = ['grad_avg', 'mixup', 'de_identification', 'mid', 'fed_pass', 'cae']
+__all__ = ['grad_avg', 'mixup', 'de_identification', 'mid', 'fed_pass', 'cae', "peloss", "dcorloss"]

--- a/benchmark_examples/autoattack/defenses/loss_defense.py
+++ b/benchmark_examples/autoattack/defenses/loss_defense.py
@@ -1,0 +1,95 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+from benchmark_examples.autoattack.applications.base import (
+    ApplicationBase,
+    InputMode,
+    ModelType,
+)
+from benchmark_examples.autoattack.attacks.base import AttackBase, AttackType
+from benchmark_examples.autoattack.defenses.base import DefenseBase
+from benchmark_examples.autoattack.utils.resources import ResourcesPack
+from secretflow_fl.ml.nn.callbacks.callback import Callback
+from secretflow_fl.ml.nn.sl.defenses.loss_defense import (
+    BaselossDefense,
+)
+
+
+class BaseLossDefenseFrontend(DefenseBase):
+    """Base class for loss-based defenses."""
+
+    def __str__(self):
+        return "loss_based_defense"
+
+    def build_defense_callback(self, app: ApplicationBase) -> Callback | None:
+        raise NotImplementedError(
+            'build_defense_callback must be implemented in subclass'
+        )
+
+    def check_attack_valid(self, attack: AttackBase) -> bool:
+        return attack.attack_type() == AttackType.LABLE_INFERENSE
+
+    def tune_metrics(self, app_metrics: Dict[str, str]) -> Dict[str, str]:
+        return {}
+
+    def check_app_valid(self, app: ApplicationBase) -> bool:
+        """only support dnn"""
+        return (
+            app.model_type()
+            in [
+                ModelType.DNN,
+                ModelType.RESNET18,
+                ModelType.VGG16,
+                ModelType.CNN,
+                ModelType.RESNET20,
+            ]
+            and app.base_input_mode() == InputMode.SINGLE
+        )
+
+    def update_resources_consumptions(
+        self,
+        cluster_resources_pack: ResourcesPack,
+        app: ApplicationBase,
+    ) -> ResourcesPack:
+        update_gpu = lambda x: x
+        update_mem = lambda x: x
+        return (
+            cluster_resources_pack.apply_debug_resources('gpu_mem', update_gpu)
+            .apply_debug_resources('memory', update_mem)
+            .apply_sim_resources(app.device_y.party, 'gpu_mem', update_gpu)
+            .apply_sim_resources(app.device_y.party, 'memory', update_mem)
+        )
+
+
+class PELossDefense(BaseLossDefenseFrontend):
+
+    def __str__(self):
+        return "peloss_defense"
+
+    def build_defense_callback(self, app: ApplicationBase, attack) -> Callback | None:
+        # angular loss may result in loss explosion
+        return BaselossDefense(loss_type='peloss', alpha=2, use_angular=False)
+
+
+class DcorLossDefense(BaseLossDefenseFrontend):
+
+    def __str__(self):
+        return "dcorloss_defense"
+
+    def build_defense_callback(self, app: ApplicationBase, attack) -> Callback | None:
+        return BaselossDefense(
+            loss_type='dcorloss', alpha=2, num_classes=app.num_classes
+        )

--- a/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
+++ b/secretflow_fl/ml/nn/sl/attacks/sim_lia_torch.py
@@ -58,6 +58,9 @@ def distance_based(measure="cosine"):
 
 
 def kmeans_based(collect_data: np.array, known_data: np.array, known_labels: dict):
+    # normalize the data before clustering will get better attack performance
+    collect_data = preprocessing.normalize(collect_data)
+    known_data = preprocessing.normalize(known_data)
 
     unique_labels = np.unique(known_labels)
     n_clusters = len(unique_labels)
@@ -160,7 +163,11 @@ class SimilarityLabelInferenceAttack(AttackCallback):
             self.known_num = 1
 
         self.attack_func = get_attack_method(self.attack_method, self.distance_metric)
-
+        print(
+            f"Using {self.attack_method} with {self.distance_metric} distance metric for attack.",
+            f"Known data number: {self.known_num}",
+            f"Data type: {self.data_type}",
+        )
         self.last_epoch = False
 
         self.res = None

--- a/secretflow_fl/ml/nn/sl/defenses/loss_defense.py
+++ b/secretflow_fl/ml/nn/sl/defenses/loss_defense.py
@@ -1,0 +1,191 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from secretflow_fl.ml.nn.callbacks.callback import Callback
+from secretflow_fl.ml.nn.core.torch import module
+from secretflow_fl.ml.nn.callbacks.callback import Callback
+from secretflow_fl.ml.nn.core.torch import loss_wrapper, module, TorchModel
+from secretflow_fl.ml.nn.sl.backend.torch.sl_base import SLBaseTorchModel
+
+
+class PELoss(nn.Module):
+    """Potential Energy Loss(PELoss) From Paper:
+    'Protecting Split Learning by Potential Energy Loss'"""
+
+    def __init__(self, alpha=2.0, use_angular=False):
+        """
+        Args:
+            alpha: weight of PE loss
+            use_angular: whether to use angular distance.
+        MENTION: angular distance perform loss explosion in some cases.
+        """
+        super().__init__()
+        self.alpha = alpha
+        self.use_angular = use_angular
+        self.eps = 1e-8
+        self.cce_loss = torch.nn.CrossEntropyLoss()
+        print(
+            f'PELoss initialized with alpha={self.alpha}, use_angular={self.use_angular}'
+        )
+
+    def forward(self, embeddings, preds, labels):
+        total_loss = 0.0
+        if isinstance(embeddings, list):
+            embeddings = embeddings[0]
+        unique_labels = torch.unique(labels)
+
+        for label in unique_labels:
+
+            mask = labels == label
+            class_emb = embeddings[mask]
+            if class_emb.shape[0] < 2:
+                continue
+            if self.use_angular:
+                class_emb = F.layer_norm(class_emb, class_emb.shape[1:])
+                class_emb = F.normalize(class_emb, dim=1, p=2)
+                cos_sim = class_emb @ class_emb.T  # cosine similarity
+                dist_matrix = torch.arccos(
+                    torch.clamp(cos_sim, -1 + self.eps, 1 - self.eps)
+                )
+            else:
+                dist_matrix = torch.cdist(class_emb, class_emb, p=2)
+
+            mask = ~torch.eye(
+                class_emb.shape[0], device=embeddings.device, dtype=torch.bool
+            )
+            dist_matrix = dist_matrix[mask]
+            loss = torch.sum(1.0 / (dist_matrix))
+            total_loss += loss / class_emb.shape[0]
+        cce_loss = self.cce_loss(preds, labels)
+        return self.alpha * total_loss + cce_loss if unique_labels.numel() > 0 else 0.0
+
+
+class DcorLoss(nn.Module):
+    """Distance Correlation Loss (DcorLoss) From Paper: 'NoPeek: Information
+    leakage reduction to share activations in distributed deep learning' and
+    'Protecting Split Learning by Potential Energy Loss'"""
+
+    def __init__(self, num_classes=10, dcor_weighting: float = 0.1) -> None:
+
+        super().__init__()
+        self.num_classes = num_classes
+        self.cce_loss = torch.nn.CrossEntropyLoss()
+        self.dcor_weighting = dcor_weighting
+        print(
+            f'DcorLoss initialized with num_classes={self.num_classes}, dcor_weighting={self.dcor_weighting}'
+        )
+
+    def forward(self, embeddings, pred, labels):
+        if isinstance(embeddings, list):
+            embeddings = embeddings[0]
+        if labels.type() != torch.int64:
+            labels = labels.long()
+        labels_onehot = F.one_hot(labels, num_classes=self.num_classes)
+        labels_onehot = labels_onehot.float()
+
+        dist_emb = self._distance_matrix(embeddings)
+        dist_label = self._distance_matrix(labels_onehot)
+        dist_emb = self._double_center(dist_emb)
+        dist_label = self._double_center(dist_label)
+
+        dcov = torch.mean(dist_emb * dist_label)
+        dvar_emb = torch.mean(dist_emb**2)
+        dvar_label = torch.mean(dist_label**2)
+
+        dcor = dcov / (torch.sqrt(dvar_emb * dvar_label) + 1e-8)
+        return self.dcor_weighting * dcor + self.cce_loss(pred, labels)
+
+    def _distance_matrix(self, x):
+        return torch.cdist(x, x, p=2)
+
+    def _double_center(self, mat):
+        row_mean = mat.mean(dim=1, keepdim=True)
+        col_mean = mat.mean(dim=0, keepdim=True)
+        total_mean = mat.mean()
+        return mat - row_mean - col_mean + total_mean
+
+
+def loss_wrapper(loss_type, **kwargss):
+    def wrapper(*args, **kwargs):
+        if loss_type == 'peloss':
+            loss_func = PELoss(**kwargss)
+        elif loss_type == 'dcorloss':
+            loss_func = DcorLoss(**kwargss)
+        else:
+            raise ValueError(f"Unsupported loss type: {loss_type}")
+        return loss_func
+
+    return wrapper
+
+
+class BaselossDefense(Callback):
+    """Base class for loss-based defenses. Can be modified to implement specific loss-based defenses."""
+
+    def __init__(self, loss_type, alpha, use_angular=False, num_classes=10, **kwargs):
+        self.loss_type = loss_type
+        self.alpha = alpha
+        self.use_angular = use_angular
+        self.num_classes = num_classes
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def inject_forward_method(worker: SLBaseTorchModel, loss_func):
+        def self_defined_forward_step(
+            self, batch, batch_idx: int, dataloader_idx: int = 0
+        ):
+            x, y = batch
+            y_pred = self(x)
+
+            self.update_metrics(y_pred, y)
+
+            if self.loss:
+                loss = self.loss(x, y_pred, y)
+                return y_pred, loss
+            else:
+                return y_pred, None
+
+        # rebuild model_fuse with new loss function.
+        # MENTION: The cnn defined not as another model.
+        # due to the loss function init in the TorchModel, the arguments of the loss hard to modify.
+        # Or you can use the decorator to wrap the loss function.
+        worker.builder_fuse = TorchModel(
+            model_fn=worker.builder_fuse.model_fn,
+            optim_fn=worker.builder_fuse.optim_fn,
+            loss_fn=loss_func,
+            metrics=worker.builder_fuse.metrics,
+            **worker.builder_fuse.kwargs,
+        )
+        worker.model_fuse = module.build(worker.builder_fuse, worker.exec_device)
+
+        worker.model_fuse.forward_step = types.MethodType(
+            self_defined_forward_step, worker.model_fuse
+        )
+
+    def on_train_begin(self, logs=None):
+        if self.loss_type == "peloss":
+            loss_func = loss_wrapper(
+                self.loss_type, alpha=self.alpha, use_angular=self.use_angular
+            )
+        elif self.loss_type == "dcorloss":
+            loss_func = loss_wrapper(
+                self.loss_type, num_classes=self.num_classes, dcor_weighting=self.alpha
+            )
+        worker = self._workers[self.device_y]
+        worker.apply(self.inject_forward_method, loss_func)

--- a/secretflow_fl/ml/nn/sl/defenses/loss_defense.py
+++ b/secretflow_fl/ml/nn/sl/defenses/loss_defense.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Implementation of the paper Protecting Split Learning by Potential Energy Loss:
+# https://www.ijcai.org/proceedings/2024/0618.pdf.
+
+
 import types
 
 import torch

--- a/tests/fl/ml/nn/sl/defenses/test_loss_defense.py
+++ b/tests/fl/ml/nn/sl/defenses/test_loss_defense.py
@@ -1,0 +1,158 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+
+import torch.nn as nn
+import torch.optim as optim
+from torchmetrics import Accuracy
+import logging
+from secretflow.data.ndarray import FedNdarray, PartitionWay
+from secretflow_fl.ml.nn import SLModel
+from secretflow_fl.ml.nn.core.torch import TorchModel, metric_wrapper, optim_wrapper
+from secretflow_fl.ml.nn.sl.attacks.sim_lia_torch import SimilarityLabelInferenceAttack
+from secretflow_fl.ml.nn.sl.defenses.loss_defense import BaselossDefense
+
+
+def do_test_sl_and_sim_lia(alice, bob, config):
+
+    class BaseNet(nn.Module):
+        def __init__(self):
+            super(BaseNet, self).__init__()
+            self.fc1 = nn.Linear(100, 100)
+            self.fc2 = nn.Linear(100, 100)
+            self.fc3 = nn.Linear(100, 100)
+            self.ReLU = nn.ReLU()
+
+        def forward(self, x):
+
+            x = self.fc1(x)
+            x = self.ReLU(x)
+            x = self.fc2(x)
+            x = self.ReLU(x)
+            x = self.fc3(x)
+            return x
+
+        def output_num(self):
+            return 1
+
+    class FuseNet(nn.Module):
+        def __init__(self):
+            super(FuseNet, self).__init__()
+            self.fc1 = nn.Linear(100, 100)
+            self.fc2 = nn.Linear(100, 10)
+            self.ReLU = nn.ReLU()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.ReLU(x)
+            x = self.fc2(x)
+            return x
+
+    train_data = np.random.rand(1000, 100).astype(np.float32)
+    train_label = np.random.randint(0, 10, size=(1000,)).astype(np.int64)
+
+    # put into FedNdarray
+    fed_data = FedNdarray(
+        partitions={
+            alice: alice(lambda x: x)(train_data),
+            # bob: bob(lambda x: x)(train_data),
+        },
+        partition_way=PartitionWay.VERTICAL,
+    )
+
+    label = bob(lambda x: x)(train_label)
+
+    # model configure
+    loss_fn = nn.CrossEntropyLoss
+
+    optim_fn = optim_wrapper(optim.SGD, lr=1e-2, momentum=0.9, weight_decay=5e-4)
+
+    _base_model, _fuse_model = BaseNet, FuseNet
+
+    base_model = TorchModel(
+        model_fn=_base_model,
+        loss_fn=loss_fn,
+        optim_fn=optim_fn,
+        metrics=[
+            metric_wrapper(
+                Accuracy, task="multiclass", num_classes=10, average="micro"
+            ),
+        ],
+    )
+
+    fuse_model = TorchModel(
+        model_fn=_fuse_model,
+        loss_fn=loss_fn,
+        optim_fn=optim_fn,
+        metrics=[
+            metric_wrapper(
+                Accuracy, task="multiclass", num_classes=10, average="micro"
+            ),
+        ],
+    )
+
+    base_model_dict = {
+        alice: base_model,
+    }
+
+    sl_model = SLModel(
+        base_model_dict=base_model_dict,
+        device_y=bob,
+        model_fuse=fuse_model,
+        simulation=True,
+        backend="torch",
+        strategy="split_nn",
+    )
+
+    loss_type, alpha = config.split(",")
+    print(loss_type)
+    if loss_type == "peloss":
+        loss_defense = BaselossDefense(
+            loss_type='peloss', alpha=int(alpha), use_angular=False
+        )
+    elif loss_type == "dcorloss":
+        loss_defense = BaselossDefense(
+            loss_type='dcorloss', alpha=int(alpha), num_classes=10
+        )
+    else:
+        raise ValueError(f"Unsupported loss type: {config}")
+
+    history = sl_model.fit(
+        fed_data,
+        label,
+        validation_data=(fed_data, label),
+        epochs=2,
+        batch_size=128,
+        random_seed=1234,
+        callbacks=[loss_defense],
+    )
+    print(history)
+
+    pred_bs = 128
+    result = sl_model.predict(fed_data, batch_size=pred_bs, verbose=1)
+
+    return result
+
+
+def test_sl_and_lia(sf_simulation_setup_devices):
+    alice = sf_simulation_setup_devices.alice
+    bob = sf_simulation_setup_devices.bob
+    config = []
+    for i in range(1, 5, 2):
+        config.append(f"peloss,{2**i}")
+        config.append(f"dcorloss,{2**i}")
+    for i in config:
+        do_test_sl_and_sim_lia(alice, bob, i)


### PR DESCRIPTION
**Type of change**

- [x] Add new papers (Please tell us why you think this paper is awesome!)
- [x] Fix the category of an existing paper/papers (Please tell us the reasons)
- [ ] Add a new tool/primitive/application with a new markdown page (Thank you! Also, please tell us more about this awesome thing!)

**Description**

## New defense method: PE Loss and Dcor Loss

Added PE loss as a defense method against LIA (Label Inference Attacks) and implemented the Dcor variant of the NoPeek method mentioned in the paper as a baseline defense algorithm. Provided design files for loss-based LIA defense methods. Testing shows compatibility with existing LIA methods and produces effective results.

PE Loss (Potential Energy Loss) and Dcor Loss (Distance Correlation Loss) are two loss functions designed to defend against label inference attacks. PE Loss counters clustering-based LIA attack methods by adjusting the spatial positioning of features through potential energy loss regulation, published in IJCAI 2024. Paper: [Protecting Split Learning by Potential Energy Loss](https://www.ijcai.org/proceedings/2024/0618.pdf)

Local testing was conducted using sim lia as the attack method, with PE loss and Dcor loss as defense methods
<img width="1262" height="178" alt="image" src="https://github.com/user-attachments/assets/dfb2dc37-03c9-40ac-9788-5b8760bb58a9" />

Partial results show the advance of the defense method. Otherwise, adjusting the hyperparameter alpha value affects defense effectiveness - higher alpha values provide better defense but may impact classification performance.

Command can be run as follows:

```bash
python benchmark_examples/autoattack/main.py mnist resnet18 sim_lia peloss
python benchmark_examples/autoattack/main.py mnist resnet18 sim_lia dcorloss
```

## Small fix of sim lia

Normalizing the feature before k-means will get better attack metrics.

