### PR TITLE
Docs:修复FLModel设计文档笔误问题

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/developer/design/flmodel.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/developer/design/flmodel.po
@@ -73,8 +73,7 @@ msgid ""
 "FLModel determines which workers are based on the parameters, and those "
 "backends will cooperate to complete the federation calculation. "
 "![flmodel](resources/flmodel.jpg)"
-msgstr "SecretFlow提供了中心化视角下的FLModel模块，联邦整体流程由FLModel来进行编排，由传入FLModel的参数来决定使用那些worker想会被拉起来进行联邦计算。![flmodel](resources/flmodel.jpg)"
-
+msgstr "SecretFlow提供了中心化视角下的FLModel模块，联邦整体流程由FLModel来进行编排。FLModel根据参数来决定哪些worker会被拉起来进行联邦计算。![flmodel](resources/flmodel.jpg)"
 #: ../../developer/design/flmodel.md:9
 msgid "flmodel"
 msgstr "flmodel"


### PR DESCRIPTION
[Fix] 修复FLModel设计文档笔误问题
文档详细地址：https://secret-flow.antgroup.com/docs/secretflow/zh_CN/developer/design/flmodel.html
关联issue：#1953 