### PR TITLE
【OSCP Docs】Fix typo: Congradulations -> Congratulations in WOE encoding doc

### DIFF
--- a/docs/user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb
+++ b/docs/user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb
@@ -353,7 +353,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congradulations!\n",
+    "Congratulations!\n",
     "In this tutorial we have learnt how to\n",
     "\n",
     "1. do WOE encoding\n",


### PR DESCRIPTION
Fixed #1870

## 修改内容
修复了 docs/user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb 文档中的拼写错误：
- \Congradulations\ → \Congratulations\

## 验证
- ✅ 文档描述正确，WOE 编码原理说明清晰
- ✅ 示例代码完整，包含完整的导入、初始化、数据处理流程
- ✅ 输出结果符合预期
- ✅ 拼写错误已修复

## OSCP Phase 5 文档季
本文档验证属于 [OSCP Phase 5 文档季](https://github.com/secretflow/secretflow/issues/1866) 活动范围。