### PR TITLE
fix: VertBinSubstitution schema mismatch after train_test_split

### DIFF
--- a/secretflow/preprocessing/binning/vert_bin_substitution.py
+++ b/secretflow/preprocessing/binning/vert_bin_substitution.py
@@ -23,11 +23,34 @@ from secretflow.compute import Table
 from secretflow.device import PYU, PYUObject, wait
 
 
+def _strip_index_columns(table: pa.Table) -> pa.Table:
+    """Remove pyarrow-generated index columns (e.g., __index_level_0__) that
+    may differ between training and inference data due to operations like
+    train_test_split with reset_index.
+
+    This ensures schema compatibility when applying binning rules built on
+    data with a different index structure.
+
+    Args:
+        table: Input pyarrow Table that may contain index columns.
+
+    Returns:
+        A pyarrow Table with index-level columns removed.
+    """
+    index_cols = [c for c in table.column_names if c.startswith("__index_level_")]
+    if index_cols:
+        for col in reversed(index_cols):
+            idx = table.column_names.index(col)
+            table = table.remove_column(idx)
+    return table
+
+
 def apply_binning_rules(
     rules: Dict, input: Union[Dict[str, np.dtype], pa.Table, pa.Schema]
 ) -> sc.Table:
     rules = {v["name"]: v for v in rules["variables"]}
     if isinstance(input, pa.Table):
+        input = _strip_index_columns(input)
         table = Table.from_pyarrow(input)
     else:
         table = Table.from_schema(input)

--- a/secretflow/preprocessing/binning/vert_bin_substitution.py
+++ b/secretflow/preprocessing/binning/vert_bin_substitution.py
@@ -23,7 +23,9 @@ from secretflow.compute import Table
 from secretflow.device import PYU, PYUObject, wait
 
 
-def _strip_index_columns(table: pa.Table) -> pa.Table:
+def _strip_index_columns(
+    data: Union[pa.Table, pa.Schema],
+) -> Union[pa.Table, pa.Schema]:
     """Remove pyarrow-generated index columns (e.g., __index_level_0__) that
     may differ between training and inference data due to operations like
     train_test_split with reset_index.
@@ -32,25 +34,31 @@ def _strip_index_columns(table: pa.Table) -> pa.Table:
     data with a different index structure.
 
     Args:
-        table: Input pyarrow Table that may contain index columns.
+        data: Input pyarrow Table or Schema that may contain index columns.
 
     Returns:
-        A pyarrow Table with index-level columns removed.
+        A pyarrow Table or Schema with index-level columns removed.
     """
-    index_cols = [c for c in table.column_names if c.startswith("__index_level_")]
-    if index_cols:
-        for col in reversed(index_cols):
-            idx = table.column_names.index(col)
-            table = table.remove_column(idx)
-    return table
+    if isinstance(data, pa.Table):
+        index_cols = [c for c in data.column_names if c.startswith("__index_level_")]
+        return data.drop(index_cols) if index_cols else data
+    elif isinstance(data, pa.Schema):
+        fields = [f for f in data if not f.name.startswith("__index_level_")]
+        return (
+            pa.schema(fields, metadata=data.metadata)
+            if len(fields) < len(data)
+            else data
+        )
+    return data
 
 
 def apply_binning_rules(
     rules: Dict, input: Union[Dict[str, np.dtype], pa.Table, pa.Schema]
 ) -> sc.Table:
     rules = {v["name"]: v for v in rules["variables"]}
-    if isinstance(input, pa.Table):
+    if isinstance(input, (pa.Table, pa.Schema)):
         input = _strip_index_columns(input)
+    if isinstance(input, pa.Table):
         table = Table.from_pyarrow(input)
     else:
         table = Table.from_schema(input)


### PR DESCRIPTION
Fixed #1330

## Bug Description

When using VertBinSubstitution.substitution() on data that has been split via 	rain_test_split(), an AssertionError is raised due to PyArrow schema mismatch.

### Reproduction

\\\python
from secretflow.data.split import train_test_split
train_data, test_data = train_test_split(vdf, train_size=0.8, shuffle=True, random_state=1234)

# Build binning rules on train data
from secretflow.preprocessing.binning.vert_binning import VertBinning
binning = VertBinning()
rules = binning.binning(vdata=train_data, ...)

# Apply substitution → AssertionError
from secretflow.preprocessing.binning.vert_bin_substitution import VertBinSubstitution
sub = VertBinSubstitution()
train_binned = sub.substitution(train_data, rules)  # 💥 AssertionError
\\\

### Error

\\\
AssertionError: y: int64
x0: double
...
__index_level_0__: int64
-- schema metadata -- ... != y: int64
x0: double
...
\\\

## Root Cause

1. When VertBinning builds rules on training data, pandas-to-pyarrow conversion may generate a \__index_level_0__\ metadata column
2. After \	rain_test_split()\ with \eset_index(drop=True)\, the index column is removed
3. \TraceRunner.run()\ at \	racer.py:88-90\ uses **strict schema equality** comparison (\in_table.schema == self.dag[0].output_schema\)
4. The schema mismatch (with vs without \__index_level_0__\) causes the AssertionError

## Fix

Add \_strip_index_columns()\ helper in \ert_bin_substitution.py\ to remove pyarrow-generated index columns (\__index_level_*\) before creating the compute trace in \pply_binning_rules()\.

This ensures schema compatibility regardless of whether the data underwent index-modifying operations.

## Why This Fix Is Safe

- **Minimal scope**: Only affects the substitution path, not binning construction
- **Index columns are not meaningful** for binning substitution logic — only feature columns matter
- **Backward compatible**: Data without index columns passes through unchanged
- **Consistent behavior**: Whether or not \	rain_test_split\ was used, the same columns are processed

## Testing

- [x] Code compiles without errors
- [x] \_strip_index_columns\ correctly removes \__index_level_*\ columns
- [x] Data without index columns passes through unchanged
- [ ] Full integration test with \	rain_test_split → VertBinning → VertBinSubstitution\ pipeline (requires SecretFlow runtime)