### PR TITLE
docs: fix typos and grammar in WOE encoding tutorial

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/user_guide/preprocessing/WeightOfEvidenceEncoding.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/user_guide/preprocessing/WeightOfEvidenceEncoding.po
@@ -95,15 +95,15 @@ msgid "Less than 0.02 -> Not useful for prediction"
 msgstr "小于0.02 -> 对预测无用"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:608
-msgid "0.02 to 0.1 -> Weak predictive Power"
+msgid "0.02 to 0.1 -> Weak predictive power"
 msgstr "0.02到0.1 -> 弱预测能力"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:610
-msgid "0.1 to 0.3 -> Medium predictive Power"
+msgid "0.1 to 0.3 -> Medium predictive power"
 msgstr "0.1到0.3 -> 中等预测能力"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:612
-msgid "0.3 to 0.5 -> Strong predictive Power"
+msgid "0.3 to 0.5 -> Strong predictive power"
 msgstr "0.3到0.5 -> 强预测能力"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:614
@@ -115,7 +115,7 @@ msgid "let’s select top 2 feature iv"
 msgstr "让我们选择前两个最重要的特征iv"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:667
-msgid "Congradulations! In this tutorial we have learnt how to"
+msgid "Congratulations! In this tutorial we have learnt how to"
 msgstr "恭喜! 在本教程中，我们学习了如何"
 
 #: ../../user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb:669

--- a/docs/user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb
+++ b/docs/user_guide/preprocessing/WeightOfEvidenceEncoding.ipynb
@@ -29,16 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Binning create buckets of independent variables based on ranking methods. Binning helps us converting continuous variables into categorical ones.\n",
-    "\n",
-    "WOE binning Implements a binning of numeric variables and factors with respect to a dichotomous target variable.\n",
-    "\n",
-    "```\n",
-    "bin_total = bin_positives + bin_negatives\n",
-    "total_labels = total_positives + total_negatives\n",
-    "bin_WOE = log((bin_positives / total_positives) / (bin_negatives / total_negatives))\n",
-    "bin_iv = ((bin_positives / total_positives) - (bin_negatives / total_negatives)) * bin_woe\n",
-    "```\n"
+    "Binning creates buckets of independent variables based on ranking methods. Binning helps us convert continuous variables into categorical ones.\n\nWOE binning implements a binning of numeric variables and factors with respect to a dichotomous target variable.\n\n```\nbin_total = bin_positives + bin_negatives\ntotal_labels = total_positives + total_negatives\nbin_WOE = log((bin_positives / total_positives) / (bin_negatives / total_negatives))\nbin_iv = ((bin_positives / total_positives) - (bin_negatives / total_negatives)) * bin_woe\n```\n"
    ]
   },
   {
@@ -318,15 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "How to interpret feature iv?\n",
-    "\n",
-    "- Less than 0.02 -> Not useful for prediction\n",
-    "- 0.02 to 0.1 -> Weak predictive Power\n",
-    "- 0.1 to 0.3 -> Medium predictive Power\n",
-    "- 0.3 to 0.5 -> Strong predictive Power\n",
-    "- >0.5\t-> Suspicious Predictive Power\n",
-    "\n",
-    "let's select top 2 feature iv"
+    "How to interpret feature iv?\n\n- Less than 0.02 -> Not useful for prediction\n- 0.02 to 0.1 -> Weak predictive power\n- 0.1 to 0.3 -> Medium predictive power\n- 0.3 to 0.5 -> Strong predictive power\n- >0.5\t-> Suspicious predictive power\n\nLet's select top 2 feature iv"
    ]
   },
   {
@@ -353,12 +336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congradulations!\n",
-    "In this tutorial we have learnt how to\n",
-    "\n",
-    "1. do WOE encoding\n",
-    "2. share some iv information to other parties\n",
-    "3. use feature iv for feature selection\n"
+    "Congratulations!\nIn this tutorial we have learnt how to\n\n1. do WOE encoding\n2. share some iv information to other parties\n3. use feature iv for feature selection\n"
    ]
   },
   {


### PR DESCRIPTION
## Overview

Fix documentation issues found during OSCP #1865 verification of the [Weight Of Evidence encoding](https://www.secretflow.org.cn/zh-CN/docs/secretflow/v1.12.0b0/user_guide/preprocessing/WeightOfEvidenceEncoding) tutorial.

Closes #1865

## Changes

### English notebook (WeightOfEvidenceEncoding.ipynb)

| Cell | Issue | Fix |
|------|-------|-----|
| Cell 3 | \Binning create buckets\ (subject-verb disagreement) | \Binning creates buckets\ |
| Cell 3 | \helps us converting\ (incorrect verb form) | \helps us convert\ |
| Cell 3 | \WOE binning Implements\ (incorrect capitalization) | \WOE binning implements\ |
| Cell 16 | \predictive Power\ x4 (inconsistent capitalization) | \predictive power\ |
| Cell 16 | \let's select\ (sentence starts with lowercase) | \Let's select\ |
| Cell 18 | **\Congradulations!\** (spelling error 🔴) | \Congratulations!\ |

### Chinese translation (WeightOfEvidenceEncoding.po)

- Fixed \Congradulations\ → \Congratulations\ in PO msgid
- Fixed \predictive Power\ → \predictive power\ in PO msgid

## Verification

All fixes are typos/grammar errors that do not affect code execution. The API usage in code cells (VertWoeBinning, VertBinSubstitution, CompVDataFrame) is consistent with the current source code.

## Multilingual Update

Both English notebook (.ipynb) and Chinese translation (.po) are updated according to [CONTRIBUTING.md](https://github.com/secretflow/secretflow/blob/main/CONTRIBUTING.md#documentation-update-and-its-multilingual-version).