### PR TITLE
docs: fix typos in data preprocessing tutorial

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/tutorial/data_preprocessing_with_data_frame.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/tutorial/data_preprocessing_with_data_frame.po
@@ -114,7 +114,7 @@ msgid ""
 msgstr "隐语提供了 `MinMaxScaler` 用于把特征缩放到最大和最小值之间。MinMaxScaler的输入和输出形式均为DataFrame。"
 
 #: ../../tutorial/data_preprocessing_with_data_frame.ipynb:553
-msgid "Here is an exmaple to scale ``sepal length (cm)`` to the [0, 1] range."
+msgid "Here is an example to scale ``sepal length (cm)`` to the [0, 1] range."
 msgstr "下面是将 `sepal length (cm)` 缩放到[0, 1]范围的示例。"
 
 #: ../../tutorial/data_preprocessing_with_data_frame.ipynb:615
@@ -128,7 +128,7 @@ msgid ""
 msgstr "隐语提供了 `StandardScaler` 进行方差缩放。StandardScaler的输入和输出行为均为DataFrame。"
 
 #: ../../tutorial/data_preprocessing_with_data_frame.ipynb:619
-msgid "Here is an exmaple to scale ``sepal length (cm)`` to unit variance."
+msgid "Here is an example to scale ``sepal length (cm)`` to unit variance."
 msgstr "下面是一个将 `sepal length (cm)` 进行方差缩放的例子。"
 
 #: ../../tutorial/data_preprocessing_with_data_frame.ipynb:681

--- a/docs/tutorial/data_preprocessing_with_data_frame.ipynb
+++ b/docs/tutorial/data_preprocessing_with_data_frame.ipynb
@@ -336,20 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tempfile\n",
-    "from secretflow.data.vertical import read_csv as v_read_csv\n",
-    "\n",
-    "# Vertical partitioning.\n",
-    "v_alice, v_bob = data.iloc[:, :2], data.iloc[:, 2:]\n",
-    "\n",
-    "# Save to temprary files.\n",
-    "_, alice_path = tempfile.mkstemp()\n",
-    "_, bob_path = tempfile.mkstemp()\n",
-    "v_alice.to_csv(alice_path, index=False)\n",
-    "v_bob.to_csv(bob_path, index=False)\n",
-    "\n",
-    "\n",
-    "df = v_read_csv({alice: alice_path, bob: bob_path})"
+    "import tempfile\nfrom secretflow.data.vertical import read_csv as v_read_csv\n\n# Vertical partitioning.\nv_alice, v_bob = data.iloc[:, :2], data.iloc[:, 2:]\n\n# Save to temporary files.\n_, alice_path = tempfile.mkstemp()\n_, bob_path = tempfile.mkstemp()\nv_alice.to_csv(alice_path, index=False)\nv_bob.to_csv(bob_path, index=False)\n\n\ndf = v_read_csv({alice: alice_path, bob: bob_path})"
    ]
   },
   {
@@ -368,24 +355,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from secretflow.data.horizontal import read_csv as h_read_csv\n",
-    "# from secretflow.security.aggregation import PlainAggregator\n",
-    "# from secretflow.security.compare import PlainComparator\n",
-    "\n",
-    "# # Horizontal partitioning.\n",
-    "# h_alice, h_bob = data.iloc[:70, :], data.iloc[70:, :]\n",
-    "\n",
-    "# # Save to temorary files.\n",
-    "# _, h_alice_path = tempfile.mkstemp()\n",
-    "# _, h_bob_path = tempfile.mkstemp()\n",
-    "# h_alice.to_csv(h_alice_path, index=False)\n",
-    "# h_bob.to_csv(h_bob_path, index=False)\n",
-    "\n",
-    "# df = h_read_csv(\n",
-    "#     {alice: h_alice_path, bob: h_bob_path},\n",
-    "#     aggregator=PlainAggregator(alice),\n",
-    "#     comparator=PlainComparator(alice),\n",
-    "# )"
+    "# from secretflow.data.horizontal import read_csv as h_read_csv\n# from secretflow.security.aggregation import PlainAggregator\n# from secretflow.security.compare import PlainComparator\n\n# # Horizontal partitioning.\n# h_alice, h_bob = data.iloc[:70, :], data.iloc[70:, :]\n\n# # Save to temporary files.\n# _, h_alice_path = tempfile.mkstemp()\n# _, h_bob_path = tempfile.mkstemp()\n# h_alice.to_csv(h_alice_path, index=False)\n# h_bob.to_csv(h_bob_path, index=False)\n\n# df = h_read_csv(\n#     {alice: h_alice_path, bob: h_bob_path},\n#     aggregator=PlainAggregator(alice),\n#     comparator=PlainComparator(alice),\n# )"
    ]
   },
   {
@@ -396,9 +366,7 @@
     "tags": []
    },
    "source": [
-    "## Preprocessing\n",
-    "\n",
-    "Secretflow provides missing value filling, standardization, categorical features encoding, discretization .etc, which are similar to sklearn's preprocessing."
+    "## Preprocessing\n\nSecretflow provides missing value filling, standardization, categorical features encoding, discretization etc., which are similar to sklearn's preprocessing."
    ]
   },
   {
@@ -466,12 +434,7 @@
     "tags": []
    },
    "source": [
-    "### Standardization\n",
-    "#### Scaling features to a range\n",
-    "\n",
-    "Secretflow provides `MinMaxScaler` for scaling features to lie between a given minimum and maximum value. The input and output of MinMaxScaler are both `DataFrame`.\n",
-    "\n",
-    "Here is an exmaple to scale `sepal length (cm)` to the [0, 1] range."
+    "### Standardization\n#### Scaling features to a range\n\nSecretflow provides `MinMaxScaler` for scaling features to lie between a given minimum and maximum value. The input and output of MinMaxScaler are both `DataFrame`.\n\nHere is an example to scale `sepal length (cm)` to the [0, 1] range."
    ]
   },
   {
@@ -508,10 +471,7 @@
    "id": "5a006c19",
    "metadata": {},
    "source": [
-    "#### Variance scaling\n",
-    "Secretflow provides `StandardScaler` for variance scaling. The input and output of StandardScaler are both DataFrames.\n",
-    "\n",
-    "Here is an exmaple to scale `sepal length (cm)` to unit variance."
+    "#### Variance scaling\nSecretflow provides `StandardScaler` for variance scaling. The input and output of StandardScaler are both DataFrames.\n\nHere is an example to scale `sepal length (cm)` to unit variance."
    ]
   },
   {
@@ -748,65 +708,7 @@
     }
    ],
    "source": [
-    "# woe binning use SPU or HEU device to protect label\n",
-    "spu = sf.SPU(sf.utils.testing.cluster_def(['alice', 'bob']))\n",
-    "\n",
-    "# Only support binary classification label dataset for now.\n",
-    "# use linear dataset as example\n",
-    "from secretflow.utils.simulation.datasets import load_linear\n",
-    "\n",
-    "vdf = load_linear(parts={alice: (1, 4), bob: (18, 22)})\n",
-    "print(f\"orig ds in alice:\\n {sf.reveal(vdf.partitions[alice].data)}\")\n",
-    "print(f\"orig ds in bob:\\n {sf.reveal(vdf.partitions[bob].data)}\")\n",
-    "\n",
-    "from secretflow.preprocessing.binning.vert_woe_binning import VertWoeBinning\n",
-    "from secretflow.preprocessing.binning.vert_bin_substitution import VertBinSubstitution\n",
-    "\n",
-    "from secretflow.data.vertical.dataframe import VDataFrame\n",
-    "from secretflow.component.core import (\n",
-    "    CompVDataFrame,\n",
-    "    VTableField,\n",
-    "    VTableFieldKind,\n",
-    "    VTableFieldType,\n",
-    "    VTableSchema,\n",
-    ")\n",
-    "\n",
-    "\n",
-    "def _build_schema(df: VDataFrame, labels: set = {\"y\"}) -> dict[str, VTableSchema]:\n",
-    "    res = {}\n",
-    "    for pyu, p in df.partitions.items():\n",
-    "        fields = []\n",
-    "        for name, dtype in p.dtypes.items():\n",
-    "            dt = VTableFieldType.from_dtype(dtype)\n",
-    "            kind = VTableFieldKind.LABEL if name in labels else VTableFieldKind.FEATURE\n",
-    "            fields.append(VTableField(name, dt, kind))\n",
-    "\n",
-    "        res[pyu.party] = VTableSchema(fields)\n",
-    "\n",
-    "    return res\n",
-    "\n",
-    "\n",
-    "vdf = CompVDataFrame.from_pandas(vdf, schemas=_build_schema(vdf))\n",
-    "\n",
-    "binning = VertWoeBinning(spu)\n",
-    "bin_rules = binning.binning(\n",
-    "    vdf,\n",
-    "    binning_method=\"quantile\",\n",
-    "    bin_num=5,\n",
-    "    bin_names={alice: [\"x1\", \"x2\", \"x3\"], bob: [\"x18\", \"x19\", \"x20\"]},\n",
-    "    label_name=\"y\",\n",
-    ")\n",
-    "\n",
-    "print(f\"bin_rules for alice:\\n {sf.reveal(bin_rules[alice])}\")\n",
-    "print(f\"bin_rules for bob:\\n {sf.reveal(bin_rules[bob])}\")\n",
-    "\n",
-    "from secretflow.preprocessing.binning.vert_bin_substitution import VertBinSubstitution\n",
-    "\n",
-    "woe_sub = VertBinSubstitution()\n",
-    "sub_data = woe_sub.substitution(vdf, bin_rules)\n",
-    "\n",
-    "print(f\"substituted ds in alice:\\n {sf.reveal(sub_data.partitions[alice].data)}\")\n",
-    "print(f\"substituted ds in bob:\\n {sf.reveal(sub_data.partitions[bob].data)}\")"
+    "# woe binning use SPU or HEU device to protect label\nspu = sf.SPU(sf.utils.testing.cluster_def(['alice', 'bob']))\n\n# Only support binary classification label dataset for now.\n# use linear dataset as example\nfrom secretflow.utils.simulation.datasets import load_linear\n\nvdf = load_linear(parts={alice: (1, 4), bob: (18, 22)})\nprint(f\"orig ds in alice:\\n {sf.reveal(vdf.partitions[alice].data)}\")\nprint(f\"orig ds in bob:\\n {sf.reveal(vdf.partitions[bob].data)}\")\n\nfrom secretflow.preprocessing.binning.vert_woe_binning import VertWoeBinning\nfrom secretflow.preprocessing.binning.vert_bin_substitution import VertBinSubstitution\n\nfrom secretflow.data.vertical.dataframe import VDataFrame\nfrom secretflow.component.core import (\n    CompVDataFrame,\n    VTableField,\n    VTableFieldKind,\n    VTableFieldType,\n    VTableSchema,\n)\n\n\ndef _build_schema(df: VDataFrame, labels: set = {\"y\"}) -> dict[str, VTableSchema]:\n    res = {}\n    for pyu, p in df.partitions.items():\n        fields = []\n        for name, dtype in p.dtypes.items():\n            dt = VTableFieldType.from_dtype(dtype)\n            kind = VTableFieldKind.LABEL if name in labels else VTableFieldKind.FEATURE\n            fields.append(VTableField(name, dt, kind))\n\n        res[pyu.party] = VTableSchema(fields)\n\n    return res\n\n\nvdf = CompVDataFrame.from_pandas(vdf, schemas=_build_schema(vdf))\n\nbinning = VertWoeBinning(spu)\nbin_rules = binning.binning(\n    vdf,\n    binning_method=\"quantile\",\n    bin_num=5,\n    bin_names={alice: [\"x1\", \"x2\", \"x3\"], bob: [\"x18\", \"x19\", \"x20\"]},\n    label_name=\"y\",\n)\n\nprint(f\"bin_rules for alice:\\n {sf.reveal(bin_rules[alice])}\")\nprint(f\"bin_rules for bob:\\n {sf.reveal(bin_rules[bob])}\")\n\n\nwoe_sub = VertBinSubstitution()\nsub_data = woe_sub.substitution(vdf, bin_rules)\n\nprint(f\"substituted ds in alice:\\n {sf.reveal(sub_data.partitions[alice].data)}\")\nprint(f\"substituted ds in bob:\\n {sf.reveal(sub_data.partitions[bob].data)}\")"
    ]
   },
   {


### PR DESCRIPTION
## Overview

Fix documentation issues found during OSCP #1869 verification of the [Data Preprocessing with DataFrame](https://www.secretflow.org.cn/zh-CN/docs/secretflow/v1.12.0b0/tutorial/data_preprocessing_with_data_frame) tutorial.

Closes #1869

## Changes

### English notebook (data_preprocessing_with_data_frame.ipynb)

| Cell | Issue | Fix |
|------|-------|-----|
| Cell 11 | \	emprary\ (spelling error) | \	emporary\ |
| Cell 13 | \	emorary\ (spelling error, in comment) | \	emporary\ |
| Cell 14 | \.etc\ (non-standard punctuation) | \etc.\ |
| Cell 18 | **\exmaple\** (spelling error 🔴) | \example\ |
| Cell 20 | **\exmaple\** (spelling error 🔴) | \example\ |
| Cell 29 | Duplicate \VertBinSubstitution\ import | Removed duplicate |

### Chinese translation (data_preprocessing_with_data_frame.po)

- Fixed \exmaple\ → \example\ in PO msgid (2 occurrences)

## Note

The tutorial uses \secretflow_fl.preprocessing\ (MinMaxScaler, OneHotEncoder, LabelEncoder, KBinsDiscretizer) which requires the separate \sf-fl\ package. This is not mentioned in the tutorial and may confuse new users. A separate follow-up could add installation instructions or a note.

## Multilingual Update

Both English notebook (.ipynb) and Chinese translation (.po) are updated according to [CONTRIBUTING.md](https://github.com/secretflow/secretflow/blob/main/CONTRIBUTING.md#documentation-update-and-its-multilingual-version).